### PR TITLE
Fix for #7

### DIFF
--- a/spec/dummy/app/views/home/index.rb
+++ b/spec/dummy/app/views/home/index.rb
@@ -28,6 +28,22 @@ class Views::Home::Index < Views::Base
             li {
               a 'Hey! This is some really long dropdown text, yo.'
             }
+            li.dropdown_menu_sub_trigger {
+              a 'View more...'
+            }
+            li {
+              ul.dropdown_menu_sub {
+                li {
+                  a 'This is one option'
+                }
+                li {
+                  a 'This is another'
+                }
+                li {
+                  a 'This is a third option'
+                }
+              }
+            }
             li {
               a 'No!'
             }

--- a/vendor/assets/javascripts/dvl/core.js
+++ b/vendor/assets/javascripts/dvl/core.js
@@ -1,3 +1,4 @@
+//= require dvl/core/dropdown_menu_sub
 //= require dvl/core/dropdowns
 //= require dvl/core/tooltips
 //= require dvl/core/modals

--- a/vendor/assets/javascripts/dvl/core/dropdown_menu_sub.coffee
+++ b/vendor/assets/javascripts/dvl/core/dropdown_menu_sub.coffee
@@ -1,0 +1,3 @@
+$(document).on 'click', '.dropdown_menu_sub_trigger a', (e) ->
+  $(e.target).parent().toggleClass('is_open')
+  false

--- a/vendor/assets/stylesheets/dvl/core/dropdowns.scss
+++ b/vendor/assets/stylesheets/dvl/core/dropdowns.scss
@@ -192,6 +192,43 @@ li.dropdown_more a {
   }
 }
 
+.dropdown_menu_sub {
+  display: none;
+}
+
+.dropdown_menu_sub_trigger {
+    position: relative;
+    &:after {
+      content: "\f105";
+      font-family: 'FontAwesome';
+      color: #bbb;
+      position: absolute;
+      right: 1rem;
+      top: 0;
+      line-height: 2.5rem;
+      font-size: 1.5rem;
+    }
+    &.is_open{
+      &:after {
+        content: "\f107";
+      }
+      & + li .dropdown_menu_sub {
+        display: block;
+      }
+    }
+}
+
+.dropdown_menu_sub li a {
+  font-size: 0.85rem;
+  padding: 0.375rem 0.5rem;
+  padding-left: 1.5rem;
+  display: block;
+  line-height: 1rem;
+  color: #777;
+  max-height: 3rem;
+  @include font_smoothing;
+}
+
 // ## Dropdown list styles
 
 


### PR DESCRIPTION
JS still needed:
- Toggle the class `.is_open` to `.dropdown_menu_sub_trigger` when it is clicked.

So apparently the line clamping stuff is a legacy Webkit feature. Any chance we can truncate these answer options with ellipses server-side (to ~120 characters or so)? It would definitely keep the DOM lighter / improve perf.
