### PR TITLE
fix focus states

### DIFF
--- a/vendor/assets/stylesheets/dvl/core/buttons.scss
+++ b/vendor/assets/stylesheets/dvl/core/buttons.scss
@@ -99,7 +99,7 @@
     box-shadow: inset 0 2px 3px hsla(0, 0%, 0%, 0.2);
   }
   &:focus {
-    outline: thin dotted $darkestGray;
+    outline: thin dotted;
     outline: 5px auto -webkit-focus-ring-color;
     outline-offset: -2px;
   }

--- a/vendor/assets/stylesheets/dvl/core/links.scss
+++ b/vendor/assets/stylesheets/dvl/core/links.scss
@@ -30,6 +30,7 @@ a {
   }
   &:focus {
     outline: thin dotted;
+    outline: 5px auto -webkit-focus-ring-color;
   }
   &.uppercase {
     // #todo consolidate this with .caps


### PR DESCRIPTION
closes #50

cribbing from bootstrap, this looks good though... "auto" seems to give
us the great behavior of only showing the focus ring when tabbing
through, not on click.