### PR TITLE
remove dropdown toggle button

### DIFF
--- a/spec/dummy/app/views/home/index.rb
+++ b/spec/dummy/app/views/home/index.rb
@@ -7,9 +7,9 @@ class Views::Home::Index < Views::Base
 
     docs 'Dropdowns', %{
       div.dropdown {
-        a.dropdown_toggle 'Click me',
-                          'data-toggle' => 'dropdown',
-                          href: '#'
+        a "Click me <i class='fa fa-caret-down'></i>".html_safe,
+          'data-toggle' => 'dropdown',
+          href: '#'
         div.dropdown_menu(role: 'menu') {
           ul.dropdown_body {
             li {
@@ -60,24 +60,29 @@ class Views::Home::Index < Views::Base
       }
 
       br
+      br
 
       div.dropdown {
-        a.dropdown_toggle_button.gray 'Click me',
-                          'data-toggle' => 'dropdown',
-                          href: '#'
+        a.button.toggle(
+          'Click me',
+          'data-toggle' => 'dropdown',
+          href: '#'
+        )
+
         div.dropdown_menu(role: 'menu') {
           ul.dropdown_body {
             li {
-              a 'This was triggered by a dropdown_toggle_button', href: '#'
+              a 'This was triggered by a button', href: '#'
             }
           }
         }
       }
 
       br
+      br
 
       div.dropdown {
-        a.dropdown_toggle_button.gray 'Notifications',
+        a.button.small.toggle 'Notifications',
                           'data-toggle' => 'dropdown',
                           href: '#'
         div.dropdown_menu(role: 'menu') {
@@ -105,9 +110,10 @@ class Views::Home::Index < Views::Base
       }
 
       br
+      br
 
       div.dropdown {
-        a.dropdown_toggle_button.gray 'Loading state',
+        a "Loading state <i class='fa fa-caret-down'></i>".html_safe,
                           'data-toggle' => 'dropdown',
                           href: '#'
         div.dropdown_menu(role: 'menu') {
@@ -122,9 +128,10 @@ class Views::Home::Index < Views::Base
       }
 
       br
+      br
 
       div.dropdown {
-        a.dropdown_toggle_button.gray 'Right item',
+        a "Right item <i class='fa fa-caret-down'></i>".html_safe,
                           'data-toggle' => 'dropdown',
                           href: '#'
         div.dropdown_menu(role: 'menu') {
@@ -197,13 +204,13 @@ class Views::Home::Index < Views::Base
           br br
 
           div.dropdown {
-            a.dropdown_toggle_button.gray 'Click me',
+            a.gray 'Click me',
                               'data-toggle' => 'dropdown',
                               href: '#'
             div.dropdown_menu(role: 'menu') {
               ul.dropdown_body {
                 li {
-                  a 'This was triggered by a dropdown_toggle_button', href: '#'
+                  a 'Item 1', href: '#'
                 }
               }
             }

--- a/vendor/assets/stylesheets/dvl/components/dropdowns.scss
+++ b/vendor/assets/stylesheets/dvl/components/dropdowns.scss
@@ -163,56 +163,6 @@ li.dropdown_more a {
 // Enhanced dropdowns:
 // Multiple lines of text, images, etc.
 
-.dropdown_toggle_button {
-  position: relative;
-  display: block;
-  text-decoration: none;
-  font-weight: $weightNormal;
-  cursor: pointer;
-  &.disabled {
-    opacity: 0.6;
-    cursor: default;
-  }
-  &:focus {
-    outline: 0;
-    border-color: $darkBlue;
-    &:after {
-      color: $darkBlue;
-    }
-  }
-  &:focus, &:hover, &:active {
-    text-decoration: none;
-  }
-  &:hover {
-    background: #fcfcfc;
-  }
-  &:active,
-  .open & {
-    background: #f7f7f7;
-  }
-  &.gray {
-    background-color: $lighterGray;
-    color: $darkestGray;
-    font-size: 0.9rem;
-    &:hover {
-      background-color: $lightGray;
-      &.disabled {
-        background-color: $lighterGray;
-      }
-    }
-    &:active,
-    .open & {
-      background-color: $lightGray;
-    }
-  }
-  &.auto {
-    width: auto;
-  }
-  &.full {
-    width: 100%;
-  }
-}
-
 .dropdown_menu_sub {
   display: none;
 }

--- a/vendor/assets/stylesheets/dvl/core/buttons.scss
+++ b/vendor/assets/stylesheets/dvl/core/buttons.scss
@@ -58,6 +58,17 @@
     font-family: 'FontAwesome';
     margin-left: 1rem;
   }
+  // Dropdown toggle button
+  &.toggle {
+    border: 1px solid $darkGray;
+
+    &:after {
+      content: "\f0d7";
+      font-family: 'FontAwesome';
+      margin-left: 0.5rem;
+      color: $darkerGray;
+    }
+  }
   &.loading {
     opacity: 0.65;
     cursor: default !important;

--- a/vendor/assets/stylesheets/dvl/core/forms.scss
+++ b/vendor/assets/stylesheets/dvl/core/forms.scss
@@ -478,14 +478,12 @@ form {
   }
 }
 
-.styled_select_wrapper,
-.dropdown_toggle_button {
+.styled_select_wrapper {
   position: relative;
   display: inline-block;
 }
 
-.styled_select,
-.dropdown_toggle_button {
+.styled_select {
   display: block;
   height: $inputHeight;
   background: #fff;


### PR DESCRIPTION
Closes https://github.com/dobtco/dvl-core/issues/72.

### Before

![img](http://take.ms/HJu7E)

### After

![img](http://take.ms/z8b3F)

@jrubenoff, am I overlooking anything? I think the "before" looks better, but "after" makes a lot more sense, since these are buttons, not `<select>`s.

For reference, this is the main place they'll be used:

![img](http://take.ms/erOTC)