### PR TITLE
Add more page header styles

### DIFF
--- a/spec/dummy/app/views/home/navigation.rb
+++ b/spec/dummy/app/views/home/navigation.rb
@@ -46,44 +46,91 @@ class Views::Home::Navigation < Views::Base
         h2 {
           a 'Page header', href: '#'
         }
+        div.page_header_secondary {
+          ul {
+            li {
+              a 'Secondary nav'
+            }
 
-        ul.page_header_secondary_nav {
-          li {
-            a 'Secondary nav'
-          }
+            li {
+              a 'A thing'
+            }
 
-          li {
-            a 'A thing'
-          }
-
-          li {
-            a 'Another thing'
+            li {
+              a 'Another thing'
+            }
           }
         }
-
-        ul.page_header_tertiary_nav {
-          li {
-            a {
-              i(class: 'fa fa-pencil')
-              text 'Tertiary nav'
+        div.page_header_tertiary {
+          ul {
+            li {
+              a {
+                i(class: 'fa fa-pencil')
+                text 'Tertiary nav'
+              }
             }
-          }
 
-          li {
-            a {
-              i(class: 'fa fa-file')
-              text 'A thing'
+            li {
+              a {
+                i(class: 'fa fa-file')
+                text 'A thing'
+              }
             }
-          }
 
-          li {
-            a {
-              text 'Another thing'
+            li {
+              a {
+                text 'Another thing'
+              }
             }
           }
         }
       }
     }, full: true, hint: '<h2> can optionally contain an <a> tag inside.'
+
+    docs 'Page Header with button and back arrow', %{
+      div.page_header.with_back_arrow {
+        a.page_header_back_arrow(title: 'Back to account', 'data-toggle' => 'tooltip') {
+          i(class: 'fa fa-arrow-circle-o-left')
+        }
+
+        h2 {
+          a 'Page header', href: '#'
+        }
+
+        div.page_header_secondary {
+          ul {
+            li {
+              a 'Secondary nav'
+            }
+
+            li {
+              a 'A thing'
+            }
+
+            li {
+              a 'Another thing'
+            }
+          }
+        }
+        div.page_header_tertiary {
+          ul {
+            li {
+              a(href: '#') {
+                text 'A thing'
+              }
+            }
+
+            li {
+              a(href: '#') {
+                text 'Another thing'
+              }
+            }
+          }
+
+          a.button.info.long_arrow 'View project', href: '#'
+        }
+      }
+    }, full: true
 
     docs 'Page subheader (h3) and actions', %{
       div.page_subheader {

--- a/vendor/assets/stylesheets/dvl/components/page_header.scss
+++ b/vendor/assets/stylesheets/dvl/components/page_header.scss
@@ -14,34 +14,52 @@
       text-decoration: none;
     }
   }
+
+  &.with_back_arrow {
+    padding-left: 2.25rem;
+  }
+}
+
+.page_header_back_arrow {
+  position: absolute;
+  top: 0;
+  left: 0;
+  font-size: 2rem;
+  line-height: 1;
 }
 
 // Secondary and tertiary navigation, within page headers.
 
-.page_header_secondary_nav,
-.page_header_tertiary_nav {
-  margin-top: 0.5rem;
-  font-weight: 600;
-  li {
-    display: inline;
-    > span {
-      color: $darkGray;
-    }
-    &.active a {
-      color: $darkestGray;
-      &:hover {
-        text-decoration: none;
+.page_header_secondary,
+.page_header_tertiary {
+  ul {
+    margin-top: 0.5rem;
+    font-weight: 600;
+    li {
+      display: inline;
+      > span {
+        color: $darkGray;
       }
-    }
-    &:last-child {
-      margin-right: 0;
+      &.active a {
+        color: $darkestGray;
+        &:hover {
+          text-decoration: none;
+        }
+      }
+      &:last-child {
+        margin-right: 0;
+      }
     }
   }
 }
 
-.page_header_secondary_nav {
+.page_header_secondary {
   float: left;
-  font-size: 0.9rem;
+  clear: left;
+  ul {
+    float: left;
+    font-size: 0.9rem;
+  }
   li {
     margin-right: 1.5rem;
     &:last-child {
@@ -50,12 +68,24 @@
   }
 }
 
-.page_header_tertiary_nav {
+.page_header_tertiary {
   float: right;
-  font-size: 0.8rem;
-  line-height: 1.8;
+  ul,
+  .button {
+    float: left;
+  }
+  ul {
+    font-size: 0.8rem;
+    line-height: 1.8;
+  }
+  li,
+  .button {
+    margin-left: 1rem;
+  }
   li {
-    margin-right: 1rem;
+    &:first-child {
+      margin-left: 0;
+    }
     a {
       color: $darkerGray;
 


### PR DESCRIPTION
These are needed for the platform redesign as well as the new "View
project" button inside of Screendoor.

- .page_header_multiline (http://take.ms/dJZnY)
- .with_back_arrow (http://take.ms/onNBR)
- .page_header_button (http://take.ms/fbWWE)

These haven't been tested cross-browser, and the .page_header_button
uses some hacks and a float order that makes me a little uncomfortable.

I thought it would be helpful to centralize our work inside of this PR
in dvl-core, though.