### PR TITLE
Fix overflow for full-width styled selects

### DIFF
--- a/vendor/assets/stylesheets/dvl/core/forms.scss
+++ b/vendor/assets/stylesheets/dvl/core/forms.scss
@@ -436,7 +436,7 @@ form {
     width: 100%;
   }
   select,
-  div {
+  select[data-width="100%"] + div {
     position: absolute;
     top: 0;
     left: 0;

--- a/vendor/assets/stylesheets/dvl/core/forms.scss
+++ b/vendor/assets/stylesheets/dvl/core/forms.scss
@@ -435,11 +435,14 @@ form {
   &.full {
     width: 100%;
   }
-  select {
+  select,
+  div {
     position: absolute;
     top: 0;
     left: 0;
     right: 0;
+  }
+  select {
     height: $inputHeight;
     opacity: 0;
     z-index: 2;


### PR DESCRIPTION
Fix this nightmare from SWFF:

![screen shot 2015-05-21 at 4 58 02 pm](https://cloud.githubusercontent.com/assets/1328849/7761433/95391d30-ffda-11e4-81b1-99ade408a6d4.png)

We can absolutely position the `select`  because we already specify the height and width of `.styled_select_wrapper`.