### PR TITLE
add delete confirmation

### DIFF
--- a/spec/dummy/app/assets/javascripts/application.js
+++ b/spec/dummy/app/assets/javascripts/application.js
@@ -10,9 +10,11 @@
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require jquery_ujs
 //= require dvl/core
 //= require dvl/helpers/flash_placeholder
 //= require dvl/helpers/toggle_class
+//= require dvl/components/delete_confirmation
 //= require dvl/components/flashes
 //= require dvl/components/dynamic_email
 //= require dvl/components/newsletter_form

--- a/spec/dummy/app/assets/javascripts/jquery_ujs.js
+++ b/spec/dummy/app/assets/javascripts/jquery_ujs.js
@@ -1,0 +1,481 @@
+(function($, undefined) {
+
+/**
+ * Unobtrusive scripting adapter for jQuery
+ * https://github.com/rails/jquery-ujs
+ *
+ * Requires jQuery 1.8.0 or later.
+ *
+ * Released under the MIT license
+ *
+ */
+
+  // Cut down on the number of issues from people inadvertently including jquery_ujs twice
+  // by detecting and raising an error when it happens.
+  if ( $.rails !== undefined ) {
+    $.error('jquery-ujs has already been loaded!');
+  }
+
+  // Shorthand to make it a little easier to call public rails functions from within rails.js
+  var rails;
+  var $document = $(document);
+
+  $.rails = rails = {
+    // Link elements bound by jquery-ujs
+    linkClickSelector: 'a[data-confirm], a[data-method], a[data-remote], a[data-disable-with], a[data-disable]',
+
+    // Button elements bound by jquery-ujs
+    buttonClickSelector: 'button[data-remote]:not(form button), button[data-confirm]:not(form button)',
+
+    // Select elements bound by jquery-ujs
+    inputChangeSelector: 'select[data-remote], input[data-remote], textarea[data-remote]',
+
+    // Form elements bound by jquery-ujs
+    formSubmitSelector: 'form',
+
+    // Form input elements bound by jquery-ujs
+    formInputClickSelector: 'form input[type=submit], form input[type=image], form button[type=submit], form button:not([type]), input[type=submit][form], input[type=image][form], button[type=submit][form], button[form]:not([type])',
+
+    // Form input elements disabled during form submission
+    disableSelector: 'input[data-disable-with]:enabled, button[data-disable-with]:enabled, textarea[data-disable-with]:enabled, input[data-disable]:enabled, button[data-disable]:enabled, textarea[data-disable]:enabled',
+
+    // Form input elements re-enabled after form submission
+    enableSelector: 'input[data-disable-with]:disabled, button[data-disable-with]:disabled, textarea[data-disable-with]:disabled, input[data-disable]:disabled, button[data-disable]:disabled, textarea[data-disable]:disabled',
+
+    // Form required input elements
+    requiredInputSelector: 'input[name][required]:not([disabled]),textarea[name][required]:not([disabled])',
+
+    // Form file input elements
+    fileInputSelector: 'input[type=file]',
+
+    // Link onClick disable selector with possible reenable after remote submission
+    linkDisableSelector: 'a[data-disable-with], a[data-disable]',
+
+    // Button onClick disable selector with possible reenable after remote submission
+    buttonDisableSelector: 'button[data-remote][data-disable-with], button[data-remote][data-disable]',
+
+    // Up-to-date Cross-Site Request Forgery token
+    csrfToken: function() {
+     return $('meta[name=csrf-token]').attr('content');
+    },
+
+    // URL param that must contain the CSRF token
+    csrfParam: function() {
+     return $('meta[name=csrf-param]').attr('content');
+    },
+
+    // Make sure that every Ajax request sends the CSRF token
+    CSRFProtection: function(xhr) {
+      var token = rails.csrfToken();
+      if (token) xhr.setRequestHeader('X-CSRF-Token', token);
+    },
+
+    // making sure that all forms have actual up-to-date token(cached forms contain old one)
+    refreshCSRFTokens: function(){
+      $('form input[name="' + rails.csrfParam() + '"]').val(rails.csrfToken());
+    },
+
+    // Triggers an event on an element and returns false if the event result is false
+    fire: function(obj, name, data) {
+      var event = $.Event(name);
+      obj.trigger(event, data);
+      return event.result !== false;
+    },
+
+    // Default confirm dialog, may be overridden with custom confirm dialog in $.rails.confirm
+    confirm: function(message) {
+      return confirm(message);
+    },
+
+    // Default ajax function, may be overridden with custom function in $.rails.ajax
+    ajax: function(options) {
+      return $.ajax(options);
+    },
+
+    // Default way to get an element's href. May be overridden at $.rails.href.
+    href: function(element) {
+      return element.attr('href');
+    },
+
+    // Submits "remote" forms and links with ajax
+    handleRemote: function(element) {
+      var method, url, data, elCrossDomain, crossDomain, withCredentials, dataType, options;
+
+      if (rails.fire(element, 'ajax:before')) {
+        elCrossDomain = element.data('cross-domain');
+        crossDomain = elCrossDomain === undefined ? null : elCrossDomain;
+        withCredentials = element.data('with-credentials') || null;
+        dataType = element.data('type') || ($.ajaxSettings && $.ajaxSettings.dataType);
+
+        if (element.is('form')) {
+          method = element.attr('method');
+          url = element.attr('action');
+          data = element.serializeArray();
+          // memoized value from clicked submit button
+          var button = element.data('ujs:submit-button');
+          if (button) {
+            data.push(button);
+            element.data('ujs:submit-button', null);
+          }
+        } else if (element.is(rails.inputChangeSelector)) {
+          method = element.data('method');
+          url = element.data('url');
+          data = element.serialize();
+          if (element.data('params')) data = data + "&" + element.data('params');
+        } else if (element.is(rails.buttonClickSelector)) {
+          method = element.data('method') || 'get';
+          url = element.data('url');
+          data = element.serialize();
+          if (element.data('params')) data = data + "&" + element.data('params');
+        } else {
+          method = element.data('method');
+          url = rails.href(element);
+          data = element.data('params') || null;
+        }
+
+        options = {
+          type: method || 'GET', data: data, dataType: dataType,
+          // stopping the "ajax:beforeSend" event will cancel the ajax request
+          beforeSend: function(xhr, settings) {
+            if (settings.dataType === undefined) {
+              xhr.setRequestHeader('accept', '*/*;q=0.5, ' + settings.accepts.script);
+            }
+            if (rails.fire(element, 'ajax:beforeSend', [xhr, settings])) {
+              element.trigger('ajax:send', xhr);
+            } else {
+              return false;
+            }
+          },
+          success: function(data, status, xhr) {
+            element.trigger('ajax:success', [data, status, xhr]);
+          },
+          complete: function(xhr, status) {
+            element.trigger('ajax:complete', [xhr, status]);
+          },
+          error: function(xhr, status, error) {
+            element.trigger('ajax:error', [xhr, status, error]);
+          },
+          crossDomain: crossDomain
+        };
+
+        // There is no withCredentials for IE6-8 when
+        // "Enable native XMLHTTP support" is disabled
+        if (withCredentials) {
+          options.xhrFields = {
+            withCredentials: withCredentials
+          };
+        }
+
+        // Only pass url to `ajax` options if not blank
+        if (url) { options.url = url; }
+
+        return rails.ajax(options);
+      } else {
+        return false;
+      }
+    },
+
+    // Handles "data-method" on links such as:
+    // <a href="/users/5" data-method="delete" rel="nofollow" data-confirm="Are you sure?">Delete</a>
+    handleMethod: function(link) {
+      var href = rails.href(link),
+        method = link.data('method'),
+        target = link.attr('target'),
+        csrfToken = rails.csrfToken(),
+        csrfParam = rails.csrfParam(),
+        form = $('<form method="post" action="' + href + '"></form>'),
+        metadataInput = '<input name="_method" value="' + method + '" type="hidden" />';
+
+      if (csrfParam !== undefined && csrfToken !== undefined) {
+        metadataInput += '<input name="' + csrfParam + '" value="' + csrfToken + '" type="hidden" />';
+      }
+
+      if (target) { form.attr('target', target); }
+
+      form.hide().append(metadataInput).appendTo('body');
+      form.submit();
+    },
+
+    // Helper function that returns form elements that match the specified CSS selector
+    // If form is actually a "form" element this will return associated elements outside the from that have
+    // the html form attribute set
+    formElements: function(form, selector) {
+      return form.is('form') ? $(form[0].elements).filter(selector) : form.find(selector);
+    },
+
+    /* Disables form elements:
+      - Caches element value in 'ujs:enable-with' data store
+      - Replaces element text with value of 'data-disable-with' attribute
+      - Sets disabled property to true
+    */
+    disableFormElements: function(form) {
+      rails.formElements(form, rails.disableSelector).each(function() {
+        rails.disableFormElement($(this));
+      });
+    },
+
+    disableFormElement: function(element) {
+      var method, replacement;
+
+      method = element.is('button') ? 'html' : 'val';
+      replacement = element.data('disable-with');
+
+      element.data('ujs:enable-with', element[method]());
+      if (replacement !== undefined) {
+        element[method](replacement);
+      }
+
+      element.prop('disabled', true);
+    },
+
+    /* Re-enables disabled form elements:
+      - Replaces element text with cached value from 'ujs:enable-with' data store (created in `disableFormElements`)
+      - Sets disabled property to false
+    */
+    enableFormElements: function(form) {
+      rails.formElements(form, rails.enableSelector).each(function() {
+        rails.enableFormElement($(this));
+      });
+    },
+
+    enableFormElement: function(element) {
+      var method = element.is('button') ? 'html' : 'val';
+      if (element.data('ujs:enable-with')) element[method](element.data('ujs:enable-with'));
+      element.prop('disabled', false);
+    },
+
+   /* For 'data-confirm' attribute:
+      - Fires `confirm` event
+      - Shows the confirmation dialog
+      - Fires the `confirm:complete` event
+
+      Returns `true` if no function stops the chain and user chose yes; `false` otherwise.
+      Attaching a handler to the element's `confirm` event that returns a `falsy` value cancels the confirmation dialog.
+      Attaching a handler to the element's `confirm:complete` event that returns a `falsy` value makes this function
+      return false. The `confirm:complete` event is fired whether or not the user answered true or false to the dialog.
+   */
+    allowAction: function(element) {
+      var message = element.data('confirm'),
+          answer = false, callback;
+      if (!message) { return true; }
+
+      if (rails.fire(element, 'confirm')) {
+        try {
+          answer = rails.confirm(message);
+        } catch (e) {
+          (console.error || console.log).call(console, e.stack || e);
+        }
+        callback = rails.fire(element, 'confirm:complete', [answer]);
+      }
+      return answer && callback;
+    },
+
+    // Helper function which checks for blank inputs in a form that match the specified CSS selector
+    blankInputs: function(form, specifiedSelector, nonBlank) {
+      var inputs = $(), input, valueToCheck,
+          selector = specifiedSelector || 'input,textarea',
+          allInputs = form.find(selector);
+
+      allInputs.each(function() {
+        input = $(this);
+        valueToCheck = input.is('input[type=checkbox],input[type=radio]') ? input.is(':checked') : input.val();
+        // If nonBlank and valueToCheck are both truthy, or nonBlank and valueToCheck are both falsey
+        if (!valueToCheck === !nonBlank) {
+
+          // Don't count unchecked required radio if other radio with same name is checked
+          if (input.is('input[type=radio]') && allInputs.filter('input[type=radio]:checked[name="' + input.attr('name') + '"]').length) {
+            return true; // Skip to next input
+          }
+
+          inputs = inputs.add(input);
+        }
+      });
+      return inputs.length ? inputs : false;
+    },
+
+    // Helper function which checks for non-blank inputs in a form that match the specified CSS selector
+    nonBlankInputs: function(form, specifiedSelector) {
+      return rails.blankInputs(form, specifiedSelector, true); // true specifies nonBlank
+    },
+
+    // Helper function, needed to provide consistent behavior in IE
+    stopEverything: function(e) {
+      $(e.target).trigger('ujs:everythingStopped');
+      e.stopImmediatePropagation();
+      return false;
+    },
+
+    //  replace element's html with the 'data-disable-with' after storing original html
+    //  and prevent clicking on it
+    disableElement: function(element) {
+      var replacement = element.data('disable-with');
+
+      element.data('ujs:enable-with', element.html()); // store enabled state
+      if (replacement !== undefined) {
+        element.html(replacement);
+      }
+
+      element.bind('click.railsDisable', function(e) { // prevent further clicking
+        return rails.stopEverything(e);
+      });
+    },
+
+    // restore element to its original state which was disabled by 'disableElement' above
+    enableElement: function(element) {
+      if (element.data('ujs:enable-with') !== undefined) {
+        element.html(element.data('ujs:enable-with')); // set to old enabled state
+        element.removeData('ujs:enable-with'); // clean up cache
+      }
+      element.unbind('click.railsDisable'); // enable element
+    }
+  };
+
+  if (rails.fire($document, 'rails:attachBindings')) {
+
+    $.ajaxPrefilter(function(options, originalOptions, xhr){ if ( !options.crossDomain ) { rails.CSRFProtection(xhr); }});
+
+    // This event works the same as the load event, except that it fires every
+    // time the page is loaded.
+    //
+    // See https://github.com/rails/jquery-ujs/issues/357
+    // See https://developer.mozilla.org/en-US/docs/Using_Firefox_1.5_caching
+    $(window).on("pageshow.rails", function () {
+      $($.rails.enableSelector).each(function () {
+        var element = $(this);
+
+        if (element.data("ujs:enable-with")) {
+          $.rails.enableFormElement(element);
+        }
+      });
+
+      $($.rails.linkDisableSelector).each(function () {
+        var element = $(this);
+
+        if (element.data("ujs:enable-with")) {
+          $.rails.enableElement(element);
+        }
+      });
+    });
+
+    $document.delegate(rails.linkDisableSelector, 'ajax:complete', function() {
+        rails.enableElement($(this));
+    });
+
+    $document.delegate(rails.buttonDisableSelector, 'ajax:complete', function() {
+        rails.enableFormElement($(this));
+    });
+
+    $document.delegate(rails.linkClickSelector, 'click.rails', function(e) {
+      var link = $(this), method = link.data('method'), data = link.data('params'), metaClick = e.metaKey || e.ctrlKey;
+      if (!rails.allowAction(link)) return rails.stopEverything(e);
+
+      if (!metaClick && link.is(rails.linkDisableSelector)) rails.disableElement(link);
+
+      if (link.data('remote') !== undefined) {
+        if (metaClick && (!method || method === 'GET') && !data) { return true; }
+
+        var handleRemote = rails.handleRemote(link);
+        // response from rails.handleRemote() will either be false or a deferred object promise.
+        if (handleRemote === false) {
+          rails.enableElement(link);
+        } else {
+          handleRemote.fail( function() { rails.enableElement(link); } );
+        }
+        return false;
+
+      } else if (method) {
+        rails.handleMethod(link);
+        return false;
+      }
+    });
+
+    $document.delegate(rails.buttonClickSelector, 'click.rails', function(e) {
+      var button = $(this);
+
+      if (!rails.allowAction(button)) return rails.stopEverything(e);
+
+      if (button.is(rails.buttonDisableSelector)) rails.disableFormElement(button);
+
+      var handleRemote = rails.handleRemote(button);
+      // response from rails.handleRemote() will either be false or a deferred object promise.
+      if (handleRemote === false) {
+        rails.enableFormElement(button);
+      } else {
+        handleRemote.fail( function() { rails.enableFormElement(button); } );
+      }
+      return false;
+    });
+
+    $document.delegate(rails.inputChangeSelector, 'change.rails', function(e) {
+      var link = $(this);
+      if (!rails.allowAction(link)) return rails.stopEverything(e);
+
+      rails.handleRemote(link);
+      return false;
+    });
+
+    $document.delegate(rails.formSubmitSelector, 'submit.rails', function(e) {
+      var form = $(this),
+        remote = form.data('remote') !== undefined,
+        blankRequiredInputs,
+        nonBlankFileInputs;
+
+      if (!rails.allowAction(form)) return rails.stopEverything(e);
+
+      // skip other logic when required values are missing or file upload is present
+      if (form.attr('novalidate') == undefined) {
+        blankRequiredInputs = rails.blankInputs(form, rails.requiredInputSelector);
+        if (blankRequiredInputs && rails.fire(form, 'ajax:aborted:required', [blankRequiredInputs])) {
+          return rails.stopEverything(e);
+        }
+      }
+
+      if (remote) {
+        nonBlankFileInputs = rails.nonBlankInputs(form, rails.fileInputSelector);
+        if (nonBlankFileInputs) {
+          // slight timeout so that the submit button gets properly serialized
+          // (make it easy for event handler to serialize form without disabled values)
+          setTimeout(function(){ rails.disableFormElements(form); }, 13);
+          var aborted = rails.fire(form, 'ajax:aborted:file', [nonBlankFileInputs]);
+
+          // re-enable form elements if event bindings return false (canceling normal form submission)
+          if (!aborted) { setTimeout(function(){ rails.enableFormElements(form); }, 13); }
+
+          return aborted;
+        }
+
+        rails.handleRemote(form);
+        return false;
+
+      } else {
+        // slight timeout so that the submit button gets properly serialized
+        setTimeout(function(){ rails.disableFormElements(form); }, 13);
+      }
+    });
+
+    $document.delegate(rails.formInputClickSelector, 'click.rails', function(event) {
+      var button = $(this);
+
+      if (!rails.allowAction(button)) return rails.stopEverything(event);
+
+      // register the pressed submit button
+      var name = button.attr('name'),
+        data = name ? {name:name, value:button.val()} : null;
+
+      button.closest('form').data('ujs:submit-button', data);
+    });
+
+    $document.delegate(rails.formSubmitSelector, 'ajax:send.rails', function(event) {
+      if (this == event.target) rails.disableFormElements($(this));
+    });
+
+    $document.delegate(rails.formSubmitSelector, 'ajax:complete.rails', function(event) {
+      if (this == event.target) rails.enableFormElements($(this));
+    });
+
+    $(function(){
+      rails.refreshCSRFTokens();
+    });
+  }
+
+})( jQuery );

--- a/spec/dummy/app/views/home/index.rb
+++ b/spec/dummy/app/views/home/index.rb
@@ -409,7 +409,12 @@ class Views::Home::Index < Views::Base
     }
 
     docs 'Delete confirmation', %{
-      a.button.error 'Delete', 'data-confirm' => 'true', href: 'delete', 'data-method' => 'delete'
+      a.button.error 'Delete', 'data-confirm' => true, href: 'delete', 'data-method' => 'delete'
+
+      br
+      br
+
+      a.button.error 'Delete', 'data-confirm' => 'Are you sure you want to delete the thing? You will lose a ton of data.', href: 'delete', 'data-method' => 'delete'
     }
 
     docs 'Tooltips', %{

--- a/spec/dummy/app/views/home/index.rb
+++ b/spec/dummy/app/views/home/index.rb
@@ -409,12 +409,16 @@ class Views::Home::Index < Views::Base
     }
 
     docs 'Delete confirmation', %{
-      a.button.error 'Delete', 'data-confirm' => true, href: 'delete', 'data-method' => 'delete'
+      a.subtle_icon('data-confirm' => true, href: 'delete', 'data-method' => 'delete'){
+        i(class: 'fa fa-minus-circle')
+      }
 
       br
       br
 
-      a.button.error 'Delete', 'data-confirm' => 'Are you sure you want to delete the thing? You will lose a ton of data.', href: 'delete', 'data-method' => 'delete'
+      a.subtle_icon('data-confirm' => 'Are you sure you want to delete the thing? You will lose a ton of data.', href: 'delete', 'data-method' => 'delete'){
+        i(class: 'fa fa-minus-circle')
+      }
     }
 
     docs 'Tooltips', %{

--- a/spec/dummy/app/views/home/index.rb
+++ b/spec/dummy/app/views/home/index.rb
@@ -408,6 +408,10 @@ class Views::Home::Index < Views::Base
       }
     }
 
+    docs 'Delete confirmation', %{
+      a.button.error 'Delete', 'data-confirm' => 'true', href: 'delete', 'data-method' => 'delete'
+    }
+
     docs 'Tooltips', %{
       %w(top right bottom left).each do |x|
         a x.capitalize,

--- a/vendor/assets/javascripts/dvl/components/delete_confirmation.coffee
+++ b/vendor/assets/javascripts/dvl/components/delete_confirmation.coffee
@@ -1,0 +1,33 @@
+$.rails.allowAction = ($link) ->
+  return true unless $link.attr('data-confirm')?
+
+  DvlDeleteConfirmation $link, ->
+    $link.removeAttr('data-confirm')
+    $link.trigger('click.rails')
+
+  false
+
+window.DvlDeleteConfirmation = ($el, cb) ->
+  $el.popover
+    html: true
+    content: """
+      <div class='popover_delete_confirmation'>
+        <a class='button error js-confirm-delete' href='#'>Delete</a>
+        <a class='button' href='#'>Cancel</a>
+      </div>
+    """
+    trigger: 'manual'
+    placement: 'bottom'
+
+  $el.popover('show')
+
+  $tip = $el.data('bs.popover').$tip
+
+  $tip.on 'click', '.button', ->
+    cb() if $(@).hasClass('js-confirm-delete')
+    $el.popover('destroy')
+
+  $('body').on 'click.delete_confirmation_body', (e) ->
+    unless $.contains($tip[0], e.target)
+      $el.popover('destroy')
+      $('body').off 'click.delete_confirmation_body'

--- a/vendor/assets/javascripts/dvl/components/delete_confirmation.coffee
+++ b/vendor/assets/javascripts/dvl/components/delete_confirmation.coffee
@@ -1,17 +1,25 @@
 $.rails.allowAction = ($link) ->
   return true unless $link.attr('data-confirm')?
 
-  DvlDeleteConfirmation $link, ->
+  DvlDeleteConfirmation $link, $link.attr('data-confirm'), ->
     $link.removeAttr('data-confirm')
     $link.trigger('click.rails')
 
   false
 
-window.DvlDeleteConfirmation = ($el, cb) ->
+window.DvlDeleteConfirmation = ($el, message, cb) ->
+  if message
+    wrappedMessage = """
+      <div class='popover_delete_confirmation_message'>
+        #{message}
+      </div>
+    """
+
   $el.popover
     html: true
     content: """
       <div class='popover_delete_confirmation'>
+        #{wrappedMessage || ''}
         <a class='button error js-confirm-delete' href='#'>Delete</a>
         <a class='button' href='#'>Cancel</a>
       </div>

--- a/vendor/assets/javascripts/dvl/core.js
+++ b/vendor/assets/javascripts/dvl/core.js
@@ -2,6 +2,7 @@
 //= require dvl/core/dropdown_menu_sub
 //= require dvl/core/dropdowns
 //= require dvl/core/tooltips
+//= require dvl/core/popovers
 //= require dvl/core/modals
 //= require dvl/core/buttons
 //= require dvl/core/styled_select

--- a/vendor/assets/javascripts/dvl/core/popovers.js
+++ b/vendor/assets/javascripts/dvl/core/popovers.js
@@ -1,0 +1,109 @@
+/* ========================================================================
+ * Bootstrap: popover.js v3.3.4
+ * http://getbootstrap.com/javascript/#popovers
+ * ========================================================================
+ * Copyright 2011-2015 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ * ======================================================================== */
+
+
++function ($) {
+  'use strict';
+
+  // POPOVER PUBLIC CLASS DEFINITION
+  // ===============================
+
+  var Popover = function (element, options) {
+    this.init('popover', element, options)
+  }
+
+  if (!$.fn.tooltip) throw new Error('Popover requires tooltip.js')
+
+  Popover.VERSION  = '3.3.4'
+
+  Popover.DEFAULTS = $.extend({}, $.fn.tooltip.Constructor.DEFAULTS, {
+    placement: 'right',
+    trigger: 'click',
+    content: '',
+    template: '<div class="popover" role="tooltip"><div class="arrow"></div><div class="popover_content"></div></div>',
+    container: 'body'
+  })
+
+
+  // NOTE: POPOVER EXTENDS tooltip.js
+  // ================================
+
+  Popover.prototype = $.extend({}, $.fn.tooltip.Constructor.prototype)
+
+  Popover.prototype.constructor = Popover
+
+  Popover.prototype.getDefaults = function () {
+    return Popover.DEFAULTS
+  }
+
+  Popover.prototype.setContent = function () {
+    var $tip    = this.tip()
+    var title   = this.getTitle()
+    var content = this.getContent()
+
+    $tip.find('.popover-title')[this.options.html ? 'html' : 'text'](title)
+    $tip.find('.popover_content').children().detach().end()[ // we use append for html objects to maintain js events
+      this.options.html ? (typeof content == 'string' ? 'html' : 'append') : 'text'
+    ](content)
+
+    $tip.removeClass('fade top bottom left right in')
+
+    // IE8 doesn't accept hiding via the `:empty` pseudo selector, we have to do
+    // this manually by checking the contents.
+    if (!$tip.find('.popover-title').html()) $tip.find('.popover-title').hide()
+  }
+
+  Popover.prototype.hasContent = function () {
+    return this.getTitle() || this.getContent()
+  }
+
+  Popover.prototype.getContent = function () {
+    var $e = this.$element
+    var o  = this.options
+
+    return $e.attr('data-content')
+      || (typeof o.content == 'function' ?
+            o.content.call($e[0]) :
+            o.content)
+  }
+
+  Popover.prototype.arrow = function () {
+    return (this.$arrow = this.$arrow || this.tip().find('.arrow'))
+  }
+
+
+  // POPOVER PLUGIN DEFINITION
+  // =========================
+
+  function Plugin(option) {
+    return this.each(function () {
+      var $this   = $(this)
+      var data    = $this.data('bs.popover')
+      var options = typeof option == 'object' && option
+
+      if (!data && /destroy|hide/.test(option)) return
+      if (!data) $this.data('bs.popover', (data = new Popover(this, options)))
+      if (typeof option == 'string') data[option]()
+    })
+  }
+
+  var old = $.fn.popover
+
+  $.fn.popover             = Plugin
+  $.fn.popover.Constructor = Popover
+
+
+  // POPOVER NO CONFLICT
+  // ===================
+
+  $.fn.popover.noConflict = function () {
+    $.fn.popover = old
+    return this
+  }
+
+}(jQuery);

--- a/vendor/assets/stylesheets/dvl/app.scss
+++ b/vendor/assets/stylesheets/dvl/app.scss
@@ -12,6 +12,8 @@
 @import "components/modals";
 @import "components/progress";
 @import "components/tooltips";
+@import "components/popovers";
+@import "components/delete_confirmation";
 @import "components/navbar";
 @import "components/page_header";
 @import "components/page_subheader";

--- a/vendor/assets/stylesheets/dvl/components/delete_confirmation.scss
+++ b/vendor/assets/stylesheets/dvl/components/delete_confirmation.scss
@@ -4,8 +4,12 @@
     padding-left: 1.5rem;
     padding-right: 1.5rem;
 
-    &:first-child {
+    &:first-of-type {
       margin-bottom: $rhythm / 2;
     }
   }
+}
+
+.popover_delete_confirmation_message {
+  margin-bottom: $rhythm / 2;
 }

--- a/vendor/assets/stylesheets/dvl/components/delete_confirmation.scss
+++ b/vendor/assets/stylesheets/dvl/components/delete_confirmation.scss
@@ -1,0 +1,11 @@
+.popover_delete_confirmation {
+  .button {
+    display: block;
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+
+    &:first-child {
+      margin-bottom: $rhythm / 2;
+    }
+  }
+}

--- a/vendor/assets/stylesheets/dvl/components/popovers.scss
+++ b/vendor/assets/stylesheets/dvl/components/popovers.scss
@@ -1,0 +1,116 @@
+//
+// Popovers
+// --------------------------------------------------
+
+$arrowSize: 7px;
+$outerArrowSize: $arrowSize + 1px;
+
+.popover {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: $z_popover;
+  display: none;
+  max-width: 276px;
+  padding: 1px;
+  font-size: 0.9rem;
+
+  background-color: $white;
+  background-clip: padding-box;
+  border: 1px solid rgba(0,0,0,.2);
+  border-radius: $radius;
+  box-shadow: 0 5px $arrowSize rgba(0,0,0,.2);
+
+  // Offset the popover to account for the popover arrow
+  &.top     { margin-top: -$arrowSize; }
+  &.right   { margin-left: $arrowSize; }
+  &.bottom  { margin-top: $arrowSize; }
+  &.left    { margin-left: -$arrowSize; }
+}
+
+.popover_content {
+  padding: 0.5rem;
+}
+
+// Arrows
+//
+// .arrow is outer, .arrow:after is inner
+
+.popover > .arrow {
+  &,
+  &:after {
+    position: absolute;
+    display: block;
+    width: 0;
+    height: 0;
+    border-color: transparent;
+    border-style: solid;
+  }
+}
+.popover > .arrow {
+  border-width: $outerArrowSize;
+}
+.popover > .arrow:after {
+  border-width: $arrowSize;
+  content: "";
+}
+
+.popover {
+  &.top > .arrow {
+    left: 50%;
+    margin-left: -$outerArrowSize;
+    border-bottom-width: 0;
+    border-top-color: #bbb;
+    bottom: -$outerArrowSize;
+    &:after {
+      content: " ";
+      bottom: 1px;
+      margin-left: -$arrowSize;
+      border-bottom-width: 0;
+      border-top-color: $white;
+    }
+  }
+  &.right > .arrow {
+    top: 50%;
+    left: -$outerArrowSize;
+    margin-top: -$outerArrowSize;
+    border-left-width: 0;
+    border-right-color: #bbb;
+    &:after {
+      content: " ";
+      left: 1px;
+      bottom: -$arrowSize;
+      border-left-width: 0;
+      border-right-color: $white;
+    }
+  }
+  &.bottom > .arrow {
+    left: 50%;
+    margin-left: -$outerArrowSize;
+    border-top-width: 0;
+    border-bottom-color: #bbb;
+    top: -$outerArrowSize;
+    &:after {
+      content: " ";
+      top: 1px;
+      margin-left: -$arrowSize;
+      border-top-width: 0;
+      border-bottom-color: $white;
+    }
+  }
+
+  &.left > .arrow {
+    top: 50%;
+    right: -$outerArrowSize;
+    margin-top: -$outerArrowSize;
+    border-right-width: 0;
+    border-left-color: #bbb;
+    &:after {
+      content: " ";
+      right: 1px;
+      border-right-width: 0;
+      border-left-color: $white;
+      bottom: -$arrowSize;
+    }
+  }
+}

--- a/vendor/assets/stylesheets/dvl/core/includes.scss
+++ b/vendor/assets/stylesheets/dvl/core/includes.scss
@@ -59,6 +59,7 @@ $lapWidth: 640px;
 $deskWidth: 960px;
 
 // x-index scale
+$z_popover: 590 !default;
 $z_dropdown: 600 !default;
 $z_tooltip: 600 !default;
 $z_navbar: 700 !default;


### PR DESCRIPTION
cf https://github.com/dobtco/screendoor-v2/issues/1841

![img](http://take.ms/BwHRW)

There's a couple of use cases where I'm not sure how to implement this properly... this is definitely better for most use cases, but maybe we should keep the modal for some use cases? Here's where I'm stuck:

![img](http://take.ms/u1m58)

![img](http://take.ms/5nDTU)

It seems like we might need to preserve the ability to show a small bit of text along with the confirmation buttons.