### PR TITLE
fix overflow for auto-width selects with long copy

### DIFF
--- a/spec/dummy/app/views/home/forms.rb
+++ b/spec/dummy/app/views/home/forms.rb
@@ -149,7 +149,7 @@ class Views::Home::Forms < Views::Base
 
         f.input :auto_width_select,
                       as: :select,
-                      collection: ['Auto width'],
+                      collection: ['Auto width', 'I am a dropdown-select this is supier long and probably overflwos onto the next line aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'],
                       include_blank: false,
                       input_html: { 'data-width' => 'auto' }
 

--- a/vendor/assets/stylesheets/dvl/core/forms.scss
+++ b/vendor/assets/stylesheets/dvl/core/forms.scss
@@ -434,6 +434,7 @@ form {
   vertical-align: middle;
   &.auto {
     width: auto;
+    max-width: 100%;
   }
   &.full {
     width: 100%;


### PR DESCRIPTION
before:

![img](http://take.ms/lyMWZ)

after:

![img](http://take.ms/DLTED)

This isn't perfect -- in fact, in Chrome, some of the text gets truncated completely:

![img](http://take.ms/yFFz7)

I still think this is better than our layout breaking.