### PR TITLE
Button contrast

### DIFF
--- a/spec/dummy/app/views/home/forms.rb
+++ b/spec/dummy/app/views/home/forms.rb
@@ -304,11 +304,12 @@ class Views::Home::Forms < Views::Page
 
     docs 'Simple', %{
       div.dvlcore_button_array {
-        a.button 'Yo!'
-        a.button.info 'Info'
-        a.button.primary 'Primary'
-        a.button.success 'Success'
-        a.button.subtle 'Subtle'
+        a.button 'Yo!', href: '#'
+        a.button.info 'Info', href: '#'
+        a.button.primary 'Primary', href: '#'
+        a.button.success 'Success', href: '#'
+        a.button.error 'Error', href: '#'
+        a.button.subtle 'Subtle', href: '#'
       }
     }, sub: true
 
@@ -332,10 +333,6 @@ class Views::Home::Forms < Views::Page
         a.button.info.arrow_l 'Previous'
         a.button.info.arrow 'Next'
         a.button.info.long_arrow 'Submit'
-        a.button.info.loading {
-          text 'Loading state'
-          i(class: 'fa fa-refresh fa-spin')
-        }
       }
     }, sub: true
 
@@ -345,6 +342,7 @@ class Views::Home::Forms < Views::Page
         a.button.info.disabled 'Info'
         a.button.primary.disabled 'Primary'
         a.button.success.disabled 'Success'
+        a.button.error.disabled 'Error'
       }
     }, hint: %{Buttons with the <code>.subtle</code> class have no disabled state. Instead, they should not be displayed on the page.}.html_safe, sub: true
 

--- a/vendor/assets/stylesheets/dvl/components/flashes.scss
+++ b/vendor/assets/stylesheets/dvl/components/flashes.scss
@@ -54,11 +54,6 @@ $dvlFlashDefaultColor: #2886A8 !default;
 
 .flash_success {
   background: $successColor;
-  color: $successTextColor;
-  .flash_close,
-  .flash_close:hover {
-    color: darken($successColor,40%);
-  }
 }
 
 @media only screen and (min-width: 768px) {

--- a/vendor/assets/stylesheets/dvl/components/labels.scss
+++ b/vendor/assets/stylesheets/dvl/components/labels.scss
@@ -26,7 +26,6 @@
 
 .label_success {
   background-color: $successColor;
-  color: $successTextColor;
 }
 
 .label_info {

--- a/vendor/assets/stylesheets/dvl/core/buttons.scss
+++ b/vendor/assets/stylesheets/dvl/core/buttons.scss
@@ -1,144 +1,87 @@
-// Buttons
-
-// Button color mixin
-
-@mixin button_color_base($bg: $lightGray,$percent: 0%) {
-  background: darken($bg, $percent);
-  border: 1px solid darken($bg, 10%);
-  @if saturation($bg) > 80% {
-    color: $white;
-  } @else if saturation($bg) == 0 {
-    @if lightness($bg) > 50% {
-      color: $darkestGray;
-    } @else {
-      color: $white;
-    }
-  } @else if lightness($bg) > 50% {
-    color: darken($bg,(40% + $percent));
-  } @else {
-    color: $white;
-  }
-}
-
-@mixin button_color($bg: $lightGray) {
-  @include button_color_base($bg);
-  &:hover,
-  &:focus {
-   @include button_color_base($bg,10%);
-    &.disabled,
-    &[disabled] {
-      background: $bg;
-    }
-  }
-  &:active {
-    box-shadow: inset 0 1px 2px darken($bg,20%);
-  }
-  &.disabled,
-  &[disabled] {
-    &:hover,
-    &:focus,
-    &:active {
-      background: $bg;
-    }
-  }
-}
-
 .button {
   display: inline-block;
   margin: 0;
   // Button height should equal $inputHeight
   padding: ((($inputHeight - $lineHeight) / 2) - 0.0625rem) ($rhythm * 2);
-  @include button_color;
   text-align: center;
   text-decoration: none;
   cursor: pointer;
   border-radius: $radius;
-  @include ellipses;
   line-height: $lineHeight;
-  border-color: $darkGray;
+  @include ellipses;
+  @include button_color($lightGray, $bodyFontColor);
+
+  // Overriding more default <a> styles
+  &:hover,
+  &:focus {
+    text-decoration: none;
+  }
+
+  // Remove the focus outline, since we'll change the background color
+  // on focus instead.
+  &:focus {
+    outline: 0;
+  }
+
+  &.disabled,
+  &[disabled] {
+    opacity: 0.65;
+    cursor: default;
+  }
+
   &.uppercase {
     border: 0 !important;
     border-radius: 0;
     text-transform: uppercase;
     font-size: $fontSmallest;
   }
+
+  // Subtle buttons don't use the button_color mixin, since they don't
+  // have a hover/focus/active state.
   &.subtle {
     background: $lightestGray;
     border-color: $lightGray;
     color: $darkerGray;
   }
+
+  // Buttons with icons
   &.arrow_l:before {
     content: "\f0d9";
     font-family: 'FontAwesome';
-    margin-right: 1rem;
+    margin-right: $rhythm * 2;
   }
   &.arrow:after {
     content: "\f0da";
     font-family: 'FontAwesome';
-    margin-left: 1rem;
+    margin-left: $rhythm * 2;
   }
   &.long_arrow:after {
     content: "\f178";
     font-family: 'FontAwesome';
-    margin-left: 1rem;
+    margin-left: $rhythm * 2;
   }
-  // Dropdown toggle button
-  &.toggle {
-    border: 1px solid $darkGray;
-    &:after {
-      content: "\f0d7";
-      font-family: 'FontAwesome';
-      margin-left: $rhythm;
-      opacity: 0.7;
-    }
+  &.toggle:after {
+    content: "\f0d7";
+    font-family: 'FontAwesome';
+    margin-left: $rhythm;
+    opacity: 0.7;
+  }
 
-    &.info, &.primary {
-      &:after {
-        color: $white;
-      }
-    }
-  }
-  &.loading {
-    opacity: 0.65;
-    cursor: default !important;
-    i {
-      margin-left: 0.5rem;
-    }
-    &.arrow:after {
-      display: none;
-    }
-  }
-  // Examples
+  // Colors
   &.primary {
-    @include button_color($secondaryColor);
+    @include button_color($secondaryColor, $white);
   }
+
   &.success {
-    @include button_color($successColor);
+    @include button_color($successColor, $white);
   }
+
   &.error {
-    @include button_color($errorColor);
+    @include button_color($errorColor, $white);
   }
+
   &.info {
-    @include button_color($primaryColor);
-  }
-  &.white {
-    @include button_color($white);
-  }
-  &.darker_gray {
-    @include button_color($gray);
-  }
-  &.light_gray {
-    @include button_color($lightestGray);
-  }
-  &.gray {
-    @include button_color($lighterGray);
-  }
-  &:hover,
-  &:focus {
-    text-decoration: none;
-  }
-  &:focus {
-    outline: 0;
+    @include button_color($primaryColor, $white);
   }
 
   // Sizes
@@ -155,19 +98,5 @@
 
   &.block {
     display: block;
-  }
-  // States
-  &.disabled,
-  &.disabled:hover,
-  &.disabled:focus,
-  &.disabled:active,
-  &[disabled],
-  &[disabled]:hover
-  &[disabled]:focus {
-    cursor: not-allowed;
-    box-shadow: none;
-    text-shadow: none;
-    opacity: 0.65;
-    cursor: default;
   }
 }

--- a/vendor/assets/stylesheets/dvl/core/includes.scss
+++ b/vendor/assets/stylesheets/dvl/core/includes.scss
@@ -22,10 +22,9 @@ $white: #fff;
 
 $primaryColor: $brandColor !default;
 $secondaryColor: #f79a68 !default;
-$successColor: #5ee0ac !default;
-$successTextColor: #172b23 !default;
+$successColor: #20b57b !default;
 $warningColor: #e3e15f !default;
-$errorColor: #d95b76 !default;
+$errorColor: #cf3353 !default;
 $highlight: #dff5f7 !default;
 
 // Blues
@@ -372,10 +371,33 @@ $easeInOutBack:  cubic-bezier(0.680, -0.550, 0.265, 1.550);
 
 // Legacy
 
-@mixin social_button_color($base_color) {
-  background: $base_color;
-  &:hover {
-    background: darken($base_color, 7%);
+@mixin button_color($bg, $text) {
+  background: $bg;
+  border: 1px solid darken($bg, 7%);
+  color: $text;
+
+  &:hover,
+  &:focus {
+    background: darken($bg, 7%);
+    border: 1px solid darken($bg, 15%);
+    color: $text;
+  }
+
+  &:active {
+    box-shadow: inset 0 1px 2px darken($bg, 20%);
+  }
+
+  // When a button is disabled, it shouldn't have a distinct
+  // hover/focus/active states.
+  &.disabled,
+  &[disabled] {
+    &:hover,
+    &:focus,
+    &:active {
+      border: 1px solid darken($bg, 7%);
+      background: $bg;
+      box-shadow: none;
+    }
   }
 }
 


### PR DESCRIPTION
Closes #135 

So Bourbon's button mixin a) is deprecated, and b) checks the "lightness" of a color and uses it to set the text size. Here's what our current colors look like when used with the Bourbon button mixin: http://take.ms/SpJ9X

It's also worth noting that both Foundation and Bootstrap's button colors do not pass WCAG AA. They're both around a 2.5 contrast ratio, and it's a problem that they've had [trouble](https://github.com/twbs/bootstrap/issues?q=is%3Aissue+contrast+ratio+is%3Aclosed) [solving](https://github.com/zurb/foundation/issues/3172) in the past. Oh, and [Primer's buttons](http://primercss.io/buttons/) are just as bad, too.

My preference is to take a pragmatic approach, and try to improve the contrast ratio of our success & error colors when used as a background for white text. I admittedly have not tried making all button text dark, but this is because I just don't think it looks good. In this PR, you'll find updated an updated `$successColor` and `$errorColor` that achieve a 3.5 and a 4.8 contrast ratio w/ white text, respectively. The success color won't pass WCAG AA since our default font size is 16px, not the 18px required for a 3.5 ratio to be acceptible. But that said, this gets us to a point where we're way better than two of the most widely-used frameworks out there. 

You'll also note that I refactored most of the code in `buttons.scss`, so you'll want to inspect and test closely. It's working fine AFAICT.

You might also want to tweak the colors that I picked. I didn't use much discretion besides "let me just pick something that's a darker than the current one".