### PR TITLE
remove margin for multiple labels

### DIFF
--- a/vendor/assets/stylesheets/dvl/components/labels.scss
+++ b/vendor/assets/stylesheets/dvl/components/labels.scss
@@ -9,9 +9,6 @@
   font-size: $fontSmaller;
   background-color: $lighterGray;
   color: $darkestGray;
-  + .label {
-    margin-left: $rhythm;
-  }
 }
 
 .label_error,


### PR DESCRIPTION
when the labels wrap over multiple lines, the behavior no longer works:

![img](http://take.ms/LQ6wB)

its better to just add a space (" ") in the DOM.