### PR TITLE
Converting CSS comments to Sass

### DIFF
--- a/vendor/assets/stylesheets/dvl/core/forms.scss
+++ b/vendor/assets/stylesheets/dvl/core/forms.scss
@@ -1,61 +1,63 @@
-/* ================================================================== *
-   Forms ($forms)
-\* ================================================================== */
+// Default form styles
+
 form {
   margin: 0;
 }
-/**
- * 1. Address `margin` set differently in Firefox 4+, Safari 5, & Chrome
- * 2. Correct `font-size` not being inherited in all browsers
- * 3. Correct `font-family` not being inherited in all browsers
- */
+
+// 1. Address `margin` set differently in Firefox 4+, Safari 5, & Chrome
+// 2. Correct `font-size` not being inherited in all browsers
+// 3. Correct `font-family` not being inherited in all browsers
+
 button,
 input,
 select,
 textarea {
-  margin: 0; /* 1 */
-  font-size: 1rem; /* 2 */
-  font-family: inherit; /* 3 */
+  margin: 0; // 1
+  font-size: 1rem; // 2
+  font-family: inherit; // 3
 }
-/**
- * Address Firefox 4+ setting `line-height` on <input> using
- * `!important` in the UA stylesheet
- */
+
+// Address Firefox 4+ setting `line-height` on <input> using
+// `!important` in the UA stylesheet
+
 button,
 input {
   line-height: normal;
 }
-/**
- * Fix inconsistent `text-transform` for <button> and <select>
- * All other form control elements do not inherit `text-transform`
- */
+
+// Fix inconsistent `text-transform` for <button> and <select>
+// All other form control elements do not inherit `text-transform`
+
 button,
 select {
   text-transform: none;
 }
-/**
- * 2. Improve usability and consistency of cursor style between
- *    image-type <input> and others
- * 3. Correct inability to style clickable <input> types in iOS
- */
+
+// 2. Improve usability and consistency of cursor style between
+//    image-type <input> and others
+// 3. Correct inability to style clickable <input> types in iOS
+
 button,
 input[type="reset"],
 input[type="submit"] {
-  cursor: pointer; /* 2 */
-  -webkit-appearance: button; /* 3 */
+  cursor: pointer; // 2
+  -webkit-appearance: button; // 3
 }
-/* Reset default `cursor` for disabled elements */
+
+// Reset default `cursor` for disabled elements
 button[disabled],
 html input[disabled] {
   cursor: default;
 }
-/* Remove default <fieldset> styles for all browsers */
+
+// Remove default <fieldset> styles for all browsers
 fieldset {
   margin: 0;
   padding: 0;
   border: 0;
 }
-/* Make most inputs, select boxes, and textareas as `block` elements */
+
+// Make most inputs, select boxes, and textareas as `block` elements
 input,
 select,
 textarea {
@@ -130,7 +132,7 @@ input[type="file"] {
   max-width: 100%;
 }
 
-/* Make checkbox, image, and radio inputs `inline-block` by default */
+// Make checkbox, image, and radio inputs `inline-block` by default
 input[type="checkbox"],
 input[type="image"],
 input[type="radio"],
@@ -140,57 +142,63 @@ input[type="file"] {
   cursor: pointer;
   border: 0;
 }
-/**
- * 1. Address `box-sizing` set to `content-box` in IE 8/9
- * 2. Remove excess padding in IE 8/9
- */
+
+// 1. Address `box-sizing` set to `content-box` in IE 8/9
+// 2. Remove excess padding in IE 8/9
+
 input[type="checkbox"],
 input[type="radio"] {
-  box-sizing: border-box; /* 1 */
+  box-sizing: border-box; // 1
   margin: 0;
-  padding: 0; /* 2 */
+  padding: 0; // 2
 }
-/**
- * 2. Address `appearance` set to `searchfield` in Safari 5 and Chrome
- */
+
+// 2. Address `appearance` set to `searchfield` in Safari 5 and Chrome
+
 input[type="search"] {
-  -webkit-appearance: textfield; /* 2 */
+  -webkit-appearance: textfield; // 2
 }
-/* Remove decoration & cancel button in Safari 5 and Chrome on OS X */
+
+// Remove decoration & cancel button in Safari 5 and Chrome on OS X
+
 input[type="search"]::-webkit-search-cancel-button,
 input[type="search"]::-webkit-search-decoration {
   -webkit-appearance: none;
 }
-/**
- * Make button, reset, and submit inputs to be `inline-block`, unless
- * otherwise specified by `.button` classes
- */
+
+// Make button, reset, and submit inputs to be `inline-block`, unless
+// otherwise specified by `.button` classes
+
 input[type="button"],
 input[type="reset"],
 input[type="submit"] {
   display: inline-block;
   width: auto;
 }
-/* Remove inner padding and border in Firefox 4+ */
+
+// Remove inner padding and border in Firefox 4+
+
 button::-moz-focus-inner,
 input::-moz-focus-inner {
   padding: 0;
   border: 0;
 }
-/* Give labels a pointer cursor by default */
+
+// Give labels a pointer cursor by default
+
 label {
   cursor: pointer;
 }
 
-/**
- * 1. Remove default vertical scrollbar in IE 8/9
- * 2. Improve readability and alignment in all browsers
- * 3. Restrict <textarea> elements to vertical resizing only
- */
+
+// 1. Remove default vertical scrollbar in IE 8/9
+// 2. Improve readability and alignment in all browsers
+// 3. Restrict <textarea> elements to vertical resizing only
+
 textarea {
-  overflow: auto; /* 1 */
-  vertical-align: top; /* 2 */
-  resize: vertical; /* 3 */
+  overflow: auto; // 1
+  vertical-align: top; // 2
+  resize: vertical; // 3
 }
 
 label.required > abbr {
@@ -484,7 +492,7 @@ form {
 }
 
 form {
-  /* Autosubmitter */
+  // Autosubmitter
   .item {
     position: relative;
   }

--- a/vendor/assets/stylesheets/dvl/core/grid.scss
+++ b/vendor/assets/stylesheets/dvl/core/grid.scss
@@ -1,33 +1,30 @@
-/**
- * Grid container
- * 1. Default gutter width, change if desired
- * 2. Remove `list-style` in case `.grid` is on a <ul> element
- * 3. Hack to remove `inline-block` whitespace - http://cbrac.co/16xcjcl
- */
+// Grid container
+// 1. Default gutter width, change if desired
+// 2. Remove `list-style` in case `.grid` is on a <ul> element
+// 3. Hack to remove `inline-block` whitespace - http://cbrac.co/16xcjcl
 
 @mixin grid() {
   margin: 0;
-  margin-left: - $gutterWidth; /* 1 */
+  margin-left: - $gutterWidth; // 1
   padding: 0;
-  list-style: none; /* 2 */
-  font-size: 0; /* 3 */
+  list-style: none; // 2
+  font-size: 0; // 3
   @media screen and (min-width: $lapWidth) {
     margin-left: - $lapGutterWidth;
   }
 }
 
-/**
- * Grid item
- * 1. Default gutter width, change if desired
- * 2. Ensures elements within `.item` start at the top
- * 3. Reset `font-size` back to normal
- */
+
+// Grid item
+// 1. Default gutter width, change if desired
+// 2. Ensures elements within `.item` start at the top
+// 3. Reset `font-size` back to normal
 
 @mixin col() {
   display: inline-block;
-  padding-left: $gutterWidth;  /* 1 */
-  vertical-align: top; /* 2 */
-  font-size: 1rem;   /* 3 */
+  padding-left: $gutterWidth;  // 1
+  vertical-align: top; // 2
+  font-size: 1rem;   // 3
   width: 100%;
   @media screen and (min-width: $lapWidth) {
     padding-left: $lapGutterWidth;
@@ -67,7 +64,8 @@
   @include col;
 }
 
-/* Widths */
+// Widths
+
 @mixin build_grid($prefix: "") {
   .#{$prefix}one_column     { @include col1; }
   .#{$prefix}two_columns    { @include col2; }

--- a/vendor/assets/stylesheets/dvl/core/links.scss
+++ b/vendor/assets/stylesheets/dvl/core/links.scss
@@ -1,8 +1,6 @@
-/* ================================================================== *\
-   Links ($links)
-\* ================================================================== */
+// Default link styles
 
-/* 1. Remove the gray background color from active links in IE 10 */
+// 1. Remove the gray background color from active links in IE 10
 a {
   background: transparent;
   color: $linkColor;

--- a/vendor/assets/stylesheets/dvl/core/print.scss
+++ b/vendor/assets/stylesheets/dvl/core/print.scss
@@ -1,14 +1,11 @@
-/* ================================================================== *\
-   Print ($print)
-   Inlined to avoid an extra HTTP request - http://cbrac.co/VUjfe3
-\* ================================================================== */
+// Print styles
 
 @media print {
-  /* 1. Black prints faster - http://cbrac.co/XvusCs */
+  // 1. Black prints faster - http://cbrac.co/XvusCs
   * {
     background: transparent !important;
     box-shadow: none !important;
-    color: #000 !important; /* 1 */
+    color: #000 !important; // 1
     text-shadow: none !important;
   }
 
@@ -25,7 +22,7 @@
     content: " (" attr(href) ")";
   }
 
-  /* Don’t show links for images, or javascript/internal links */
+  // Don’t show links for images, or javascript/internal links
   a[href^="#"]:after,
   a[href^="javascript:"]:after,
   .ir a:after {
@@ -64,6 +61,6 @@
   }
 
   thead {
-    display: table-header-group; /* http://cbrac.co/Q6s1o2 */
+    display: table-header-group; // http://cbrac.co/Q6s1o2
   }
 }

--- a/vendor/assets/stylesheets/dvl/core/resets.scss
+++ b/vendor/assets/stylesheets/dvl/core/resets.scss
@@ -1,8 +1,6 @@
-/* ================================================================== *\
-   Base ($base)
-\* ================================================================== */
+// Base
 
-/* Viewport resizing */
+// Viewport resizing
 @-webkit-viewport {
   width: device-width;
   zoom: 1.0;
@@ -24,42 +22,37 @@
   zoom: 1.0;
 }
 
-/**
- * Box model adjustments
- * `border-box`... ALL THE THINGS - http://cbrac.co/RQrDL5
- */
+// Box model adjustments
+// `border-box`... ALL THE THINGS - http://cbrac.co/RQrDL5
 
 *, *:before, *:after {
   box-sizing: border-box;
 }
 
-/* Correct `block` display not defined in IE 8/9 */
+// Correct `block` display not defined in IE 8/9
+
 article, aside, details, figcaption, figure, footer, header, hgroup, main, nav, section, summary {
   display: block;
 }
 
-/**
- * Address [hidden] styling not present in IE 8/9
- * Hide the <template> element in IE, Safari, and Firefox < 22
- */
+// Address [hidden] styling not present in IE 8/9
+// Hide the <template> element in IE, Safari, and Firefox < 22
 
 [hidden], template {
   display: none;
 }
 
-/* Set <html> and <body> to inherit the height of the viewport */
+// Set <html> and <body> to inherit the height of the viewport
 html, body {
   min-height: 100%;
 }
 
-/**
- * 1. Force a vertical scrollbar - http://cbrac.co/163MspB
- * 2. Remove text size adjustments without disabling user zoom
- * NOTE: Use `text-rendering` with caution - http://cbrac.co/SJt8p1
- * NOTE: Avoid the webkit anti-aliasing trap - http://cbrac.co/TAdhbH
- * NOTE: IE for Windows Phone 8 ignores `-ms-text-size-adjust` if the
- *       viewport <meta> tag is used - http://cbrac.co/1cFrAvl
- */
+// 1. Force a vertical scrollbar - http://cbrac.co/163MspB
+// 2. Remove text size adjustments without disabling user zoom
+// NOTE: Use `text-rendering` with caution - http://cbrac.co/SJt8p1
+// NOTE: Avoid the webkit anti-aliasing trap - http://cbrac.co/TAdhbH
+// NOTE: IE for Windows Phone 8 ignores `-ms-text-size-adjust` if the
+//      viewport <meta> tag is used - http://cbrac.co/1cFrAvl
 
 html {
   overflow-y: scroll;
@@ -68,10 +61,8 @@ html {
   text-size-adjust: 100%;
 }
 
-/**
- * 1. Customize `background` for text selections
- * 2. Remove `text-shadow` selection highlight - http://cbrac.co/Q6swON
- */
+// 1. Customize `background` for text selections
+// 2. Remove `text-shadow` selection highlight - http://cbrac.co/Q6swON
 
 ::-moz-selection,
 ::selection {
@@ -80,12 +71,12 @@ html {
   text-shadow: none;
 }
 
-/* Change `background` for text selections when browser is unfocused */
+// Change `background` for text selections when browser is unfocused */
 ::selection:window-inactive {
   background: rgba($selectionBackground,0.4);
 }
 
-/* Remove `background` on images when selected */
+// Remove `background` on images when selected */
 img::selection, img::-moz-selection {
   background: transparent;
 }

--- a/vendor/assets/stylesheets/dvl/core/tables.scss
+++ b/vendor/assets/stylesheets/dvl/core/tables.scss
@@ -5,8 +5,8 @@
 table {
   max-width: 100%;
   width: 100%;
-  border-spacing: 0;         /* 1 */
-  border-collapse: collapse; /* 1 */
+  border-spacing: 0;
+  border-collapse: collapse;
   empty-cells: show;
   word-break: break-word;
   // Avoid single-line inputs wrapping to multiple lines
@@ -59,7 +59,7 @@ th {
 
 td {
   padding: $rhythm * 2;
-  border-color: $lightGray; 
+  border-color: $lightGray;
 }
 
 th.sortable a {

--- a/vendor/assets/stylesheets/dvl/core/typography.scss
+++ b/vendor/assets/stylesheets/dvl/core/typography.scss
@@ -1,31 +1,23 @@
-/* ================================================================== *
-   Typography ($typography)
-
-   Modular scale:    12px @ 1:1.333 (perfect fourth)
-   Important number: 20px (maximum <html> `font-size`)
-   http://modularscale.com/scale/?px1=12&px2=20&ra1=1.333&ra2=0
-\* ================================================================== */
-
 html {
   font-size: $maxFontSize;
 }
 
-/**
- * 1. Remove default `margin`
- * 2. Inherits percentage declared on above <html> as root `font-size`
- * 3. Unitless `line-height`, which acts as multiple of root `font-size`
- */
+// 1. Remove default `margin`
+// 2. Inherits percentage declared on above <html> as root `font-size`
+// 3. Unitless `line-height`, which acts as multiple of root `font-size`
 
 body {
-  margin: 0; /* 1 */
+  margin: 0; // 1
   background: $bodyBackgroundColor;
   color: $bodyFontColor;
-  font-size: 1rem; /* 2 */
+  font-size: 1rem; // 2
   font-family: $fontFamilyDefault;
   font-weight: $weightNormal;
-  line-height: $unitlessLineHeight; /* 3 */
+  line-height: $unitlessLineHeight; // 3
 }
-/* Address style set to `bolder` in Firefox 4+, Safari 5, and Chrome */
+
+// Address style set to `bolder` in Firefox 4+, Safari 5, and Chrome
+
 b,
 strong {
   font-weight: $weightBold;
@@ -61,7 +53,8 @@ cite {
   font-style: italic;
 }
 
-/* NOTE: Use `text-rendering` with caution - http://cbrac.co/SJt8p1 */
+// NOTE: Use `text-rendering` with caution - http://cbrac.co/SJt8p1
+
 h1,
 h2,
 h3,
@@ -146,14 +139,15 @@ del {
   }
 }
 
-/* 1. Address inconsistent and variable `font-size` in all browsers */
+// 1. Address inconsistent and variable `font-size` in all browsers
 small {
   display: inline-block;
   font-size: $fontSmaller;
   line-height: $lineHeight;
 }
 
-/* Prevent <sub> and <sup> affecting `line-height` in all browsers */
+// Prevent <sub> and <sup> affecting `line-height` in all browsers
+
 sub,
 sup {
   position: relative;


### PR DESCRIPTION
We appear to be hosting non-minified CSS on our production splash pages, complete with CSS comments:

![screen shot 2015-08-05 at 10 45 07 pm](https://cloud.githubusercontent.com/assets/1328849/9104631/bcf8f3b6-3bc3-11e5-8a9c-189ff7de5666.png)

Even though the core problem here is a build issue with our splash pages, this PR future-proofs us a bit.