### PR TITLE
Better font stack

### DIFF
--- a/vendor/assets/stylesheets/dvl/core/includes.scss
+++ b/vendor/assets/stylesheets/dvl/core/includes.scss
@@ -84,8 +84,8 @@ $weightNormal: 400 !default;
 $weightBold: 700 !default;
 
 // Typography
-$fontFamilyDefault: 'franklin-gothic-urw', 'Helvetica Neue', Arial, sans-serif !default;
-$fontFamilyDisplay: 'source-sans-pro', 'HelveticaNeue', Helvetica, Arial, sans-serif !default;
+$fontFamilyDefault: 'franklin-gothic-urw', 'Franklin Gothic Medium', 'Franklin Gothic', 'ITC Franklin Gothic', 'Helvetica Neue', Arial, sans-serif !default;
+$fontFamilyDisplay: 'source-sans-pro', 'HelveticaNeue-Light', Helvetica, Arial, sans-serif !default;
 $fontFamilyMonospace: 'Consolas', 'Monaco', 'Lucida Console', monospace !default;
 $unitlessRhythm: 0.5 !default; // 8px @ 16px root
 $rhythm: $unitlessRhythm * 1rem !default;


### PR DESCRIPTION
Better font fallbacks in the event that Typekit does not load.

Macs have a light weight of Helvetica Neue pre-installed. PCs have Franklin Gothic pre-installed.

Before (Mac):

![screen shot 2015-08-05 at 11 35 35 pm](https://cloud.githubusercontent.com/assets/1328849/9105250/e4fe523c-3bca-11e5-98e2-fa86cf1a298e.png)

After (Mac):

![screen shot 2015-08-05 at 11 35 43 pm](https://cloud.githubusercontent.com/assets/1328849/9105262/041935ec-3bcb-11e5-8254-d6e00a6a4fda.png)

After (Windows):

![screen shot 2015-08-05 at 11 36 21 pm](https://cloud.githubusercontent.com/assets/1328849/9105264/06f3f95a-3bcb-11e5-8830-e862a6eb1d75.png)
