### PR TITLE
Attempting to style FOUT to match webfonts

### DIFF
--- a/spec/dummy/app/views/base.rb
+++ b/spec/dummy/app/views/base.rb
@@ -8,7 +8,7 @@ class Views::Base < Erector::Widget
     script src: '//code.jquery.com/jquery-1.11.1.min.js'
     javascript_include_tag 'application'
     script src: '//use.typekit.net/ckb1dps.js'
-    script 'try{Typekit.load();}catch(e){}'.html_safe
+    script 'try{Typekit.load({async: true});}catch(e){}'.html_safe
   end
 
   def content

--- a/vendor/assets/stylesheets/dvl/core/includes.scss
+++ b/vendor/assets/stylesheets/dvl/core/includes.scss
@@ -93,6 +93,9 @@ $unitlessLineHeight: $unitlessRhythm * 3 !default; // 24px
 $lineHeight: $unitlessLineHeight * 1rem !default;
 $maxFontSize: 100% !default; // 16px
 
+$fontDefaultFallback: 0.9375;
+$fontDisplayFallback: 0.875;
+
 $ratio: 1.5;
 
 // Font Sizes - Large Screens
@@ -133,7 +136,12 @@ $fontLineHeightH3Mobile: 4 * $rhythm !default; // 32px
   @include fontDisplay;
   @media screen and (min-width: $lapWidth) {
     margin-left: -0.3125rem; // Optically align Source Sans with body text
-    font-size: $fontSizeH1;
+    font-size: $fontSizeH1 * $fontDisplayFallback;
+    letter-spacing: 0.05rem;
+    .wf-sourcesanspro-n3-active & {
+      font-size: $fontSizeH1;
+      letter-spacing: 0;
+    }
     line-height: $fontLineHeightH1;
   }
 }
@@ -144,7 +152,12 @@ $fontLineHeightH3Mobile: 4 * $rhythm !default; // 32px
   font-weight: $weightNormal;
   @media screen and (min-width: $lapWidth) {
     margin-left: -0.125rem; // Optically align Source Sans with body text
-    font-size: $fontSizeH2;
+    font-size: $fontSizeH2 * $fontDisplayFallback;
+    letter-spacing: 0.02rem;
+    .wf-active & {
+      font-size: $fontSizeH2;
+      letter-spacing: 0;
+    }
     line-height: $fontLineHeightH2;
     @include fontDisplay;
   }
@@ -155,7 +168,10 @@ $fontLineHeightH3Mobile: 4 * $rhythm !default; // 32px
   line-height: $fontLineHeightH3Mobile;
   font-weight: $weightNormal;
   @media screen and (min-width: $lapWidth) {
-    font-size: $fontSizeH3;
+    font-size: $fontSizeH3 * $fontDefaultFallback;
+    .wf-active & {
+      font-size: $fontSizeH3;
+    }
     line-height: $fontLineHeightH3;
   }
 }

--- a/vendor/assets/stylesheets/dvl/core/typography.scss
+++ b/vendor/assets/stylesheets/dvl/core/typography.scss
@@ -43,6 +43,10 @@ summary,
 table,
 ul {
   margin: 0 0 $lineHeight;
+  font-size: 1rem * $fontDefaultFallback;
+  .wf-active & {
+    font-size: 1rem;
+  }
 }
 
 dt {
@@ -77,9 +81,6 @@ h2,
 h3,
 h4 {
   margin: 0 0 $lineHeight;
-}
-
-h1, h2, h3, h4 {
   @include font_smoothing;
 }
 
@@ -96,7 +97,10 @@ h3 {
 }
 
 h4 {
-  font-size: 1rem;
+  font-size: 1rem * $fontDefaultFallback;
+  .wf-active {
+    font-size: 1rem;
+  }
   font-weight: $weightBold;
   line-height: $lineHeight;
 }


### PR DESCRIPTION
Looking for feedback here. Very simple question, but hard to explain.

Our webfonts are 150KB. If we load them asynchronously, it's a huge performance gain. (For our static sites, we'd cut load times in half.)

The problem is that the discrepancy between our webfonts and fallbacks is very jarring, so the initial experience would suck. Toggling between two tabs here:

![before](https://cloud.githubusercontent.com/assets/1328849/9126590/fcf6513e-3c63-11e5-9259-7d1dcca4d9e0.gif)

-----

So, a lesson: setting `font-size: 1rem;` does not actually specify the height of a typeface's letterforms. ems refer to [the height of the block](http://media.creativebloq.futurecdn.net/sites/creativebloq.com/files/images/2013/06/letterpress.jpg) in which the type designer can draw each character. The actual height of the character can vary wildly.

We can make our fallback fonts match our webfonts by resizing them. It works really well. Here are the results:

![after](https://cloud.githubusercontent.com/assets/1328849/9126744/55148366-3c66-11e5-8551-e43a948caec5.gif)


----

In practice, though, when you actually try to use the site, it's not great.

![fontjump](https://cloud.githubusercontent.com/assets/1328849/9126633/93314884-3c64-11e5-936f-96373ef9320b.gif)

----

Here's what's happening: Typekit fonts have already been cached, but the JS is still adding the `.wf-loading` and `.wf-active` classes. So the user sees the font sizes intended for the fallbacks, right before the real font size.

How might we mitigate this?

Brainstorming: maybe we could fade the text in after webfonts are loaded, but only when webfonts are cached, since we know the delay will be short.