### PR TITLE
Fix page subheader link margins

### DIFF
--- a/vendor/assets/stylesheets/dvl/components/page_subheader.scss
+++ b/vendor/assets/stylesheets/dvl/components/page_subheader.scss
@@ -35,7 +35,8 @@
   a {
     float: left;
     margin-right: $lineHeight;
-    &:last-child {
+    &:last-child,
+    &:last-of-type {
       margin-right: 0;
     }
   }


### PR DESCRIPTION
This margin shouldn't be there:

![screen shot 2015-08-13 at 1 38 40 am](https://cloud.githubusercontent.com/assets/1328849/9245833/248b6a16-415c-11e5-9419-ff8c1fab73a4.png)
