### PR TITLE
Fix focus color for dropdowns

### DIFF
--- a/vendor/assets/stylesheets/dvl/components/dropdowns.scss
+++ b/vendor/assets/stylesheets/dvl/components/dropdowns.scss
@@ -116,6 +116,9 @@
         text-decoration: none;
         background-color: rgba($linkColor,0.04);
       }
+      &:focus {
+        outline: 1px dotted $darkerGray;
+      }
     }
     &.divider {
       // Dividers separating items
@@ -366,7 +369,7 @@
       padding-right: $lineHeight + ($rhythm * 2); // Making room for the icon
     }
     &.is_focused {
-      background: $lighterGray;
+      background: rgba($linkColor,0.04);
     }
     &:after {
       line-height: 1;


### PR DESCRIPTION
Focus states for `.dropdown_filter` are the same color as the dropdown header:

![screen shot 2015-08-25 at 12 26 59 pm](https://cloud.githubusercontent.com/assets/1328849/9476982/a4ce1670-4b24-11e5-91f8-c884381fef8d.png)

This PR fixes that, and also improves the default focus state:

![screen shot 2015-08-25 at 12 28 04 pm](https://cloud.githubusercontent.com/assets/1328849/9477023/df832a94-4b24-11e5-834d-8bfcee7e453e.png)

![screen shot 2015-08-25 at 12 27 43 pm](https://cloud.githubusercontent.com/assets/1328849/9477028/e26a50de-4b24-11e5-85b8-a9b692888ac4.png)
