### PR TITLE
Smaller font size for pre tags

### DIFF
--- a/vendor/assets/stylesheets/dvl/core/code.scss
+++ b/vendor/assets/stylesheets/dvl/core/code.scss
@@ -30,4 +30,5 @@ pre {
   word-break: normal;
   @include font_smoothing;
   letter-spacing: 0.02rem;
+  font-size: $fontSmaller;
 }


### PR DESCRIPTION
Our code snippets are hilariously large.

Before:

![screen shot 2015-08-28 at 11 53 05 am](https://cloud.githubusercontent.com/assets/1328849/9554562/87e453a4-4d7b-11e5-86ad-940859afac5a.png)

After:

![screen shot 2015-08-28 at 11 53 00 am](https://cloud.githubusercontent.com/assets/1328849/9554563/8c241f12-4d7b-11e5-9a93-ba8e105a57d6.png)
