### PR TITLE
more fanciness for blank options

### DIFF
--- a/app/inputs/dropdown_select_input.rb
+++ b/app/inputs/dropdown_select_input.rb
@@ -31,7 +31,12 @@ class DropdownSelectInput < SimpleForm::Inputs::CollectionInput
       content_tag(:div, class: 'dropdown_menu dropdown_menu_rich', role: 'menu') {
         content_tag(:ul, class: 'dropdown_body') {
           collection.map do |x|
-            content_tag(:li, class: selected_option == x ? 'active' : nil) {
+            li_class_str = [].tap do |arr|
+              arr << 'active' if selected_option == x
+              arr << 'blank' if x[1].blank?
+            end.join(' ').presence
+
+            content_tag(:li, class: li_class_str) {
               content_tag(:a, 'data-value' => x[1], href: '#') {
                 content_tag(:strong, class: 'drop_rich_head') { x[0] } +
                 content_tag(:span, class: 'drop_rich_subhead') { x[2] }

--- a/spec/dummy/app/assets/javascripts/preview.coffee
+++ b/spec/dummy/app/assets/javascripts/preview.coffee
@@ -1,8 +1,8 @@
 $ ->
   $('[data-toggle="tooltip"]').tooltip()
-  $('body').styledSelect(blank: 'Choose an option')
+  $('body').styledSelect(blank: '(Choose an option)')
   $('body').styledControls()
-  $('body').dropdownSelect(blank: 'Choose an option')
+  $('body').dropdownSelect(blank: '(Choose an option)')
   $("input.datetime_picker").datetimePicker()
 
 $(document).on 'click', '.docs_toggle_button', ->

--- a/spec/dummy/app/views/home/forms.rb
+++ b/spec/dummy/app/views/home/forms.rb
@@ -57,6 +57,16 @@ class Views::Home::Forms < Views::Page
                 ],
                 include_blank: true
 
+        f.input :select,
+                as: :select,
+                label: 'Selects can include placeholder text for blank options',
+                collection: [
+                  ['Caucasian', 1],
+                  ['Black / African-American', 2],
+                  ['American Indian / Alaskan National', 3]
+                ],
+                include_blank: 'None selected'
+
       f.input :select,
               as: :select,
               label: 'This dropdown has a fixed width of 14rem.',
@@ -89,7 +99,7 @@ class Views::Home::Forms < Views::Page
                 label: 'Rich-text dropdowns can be blank by default.',
                 collection: [['Option 1', 'action', 'Description'],
                 ['An example of a very long Option 2. This should not be a problem, because the text should wrap to multiple lines.', 'action', 'Description']],
-                include_blank: true
+                include_blank: 'None selected'
       end
     }, hint: 'This component lets you add long answer options, or descriptive text to each option, while imitating the behavior of a native <code>&lt;select&gt;</code>.'.html_safe, sub: true
 

--- a/vendor/assets/javascripts/dvl/components/dropdown_select.coffee
+++ b/vendor/assets/javascripts/dvl/components/dropdown_select.coffee
@@ -9,7 +9,7 @@ class DropdownSelectInput
     @$input = $el.find('input')
     @$toggle = $el.find('[data-toggle=dropdown]')
 
-    for i in ['width']
+    for i in ['width', 'blank']
       @options[i] = @$input.data(i) if @$input.data(i)?
 
     @setWidth()
@@ -41,11 +41,11 @@ class DropdownSelectInput
   _setText: ->
     newText = @$el.find('li.active .drop_rich_head').text()
 
-    if newText
+    if @$input.val()
       @$toggle.text(newText)
       @$toggle.removeClass('is_blank')
     else
-      @$toggle.text(@options.blank)
+      @$toggle.text(@options.blank || newText)
       @$toggle.addClass('is_blank')
 
   setWidth: ->

--- a/vendor/assets/javascripts/dvl/core/styled_select.coffee
+++ b/vendor/assets/javascripts/dvl/core/styled_select.coffee
@@ -7,7 +7,7 @@ class StyledSelect
     @$el = $el
     @options = $.extend({}, @defaults, options)
 
-    for i in ['width']
+    for i in ['width', 'blank']
       @options[i] = @$el.data(i) if @$el.data(i)?
 
     @initWrapper()
@@ -30,11 +30,13 @@ class StyledSelect
       @$wrapper.width(@options.width)
 
   _change: ->
-    if (text = @$el.find('option:selected').text())
-      @$span.text(text)
+    $selected = @$el.find('option:selected')
+
+    if $selected.val()
+      @$span.text($selected.text())
       @$span.removeClass('is_blank')
     else
-      @$span.text(@options.blank)
+      @$span.text(@options.blank || $selected.text())
       @$span.addClass('is_blank')
 
 window.StyledSelect = StyledSelect

--- a/vendor/assets/stylesheets/dvl/components/dropdown_select.scss
+++ b/vendor/assets/stylesheets/dvl/components/dropdown_select.scss
@@ -22,6 +22,9 @@
 .drop_rich_head {
   color: $black;
   font-weight: $weightNormal;
+  .blank a & {
+    color: $darkGray;
+  }
   .active a & {
     color: $white;
     @include font_smoothing(off);


### PR DESCRIPTION
- for regular `<select>`s, allow placeholder text to be different than blank <option> text

- for `.dropdown_select`s, allow placeholder text to be different than blank <option> text. also add `.blank` class to blank option in dropdown.

closes #153