### PR TITLE
Switch display typeface to Trade Gothic Wide

### DIFF
--- a/spec/dummy/app/views/home/index.rb
+++ b/spec/dummy/app/views/home/index.rb
@@ -32,8 +32,8 @@ class Views::Home::Index < Views::Home
 
     docs 'Headings', %{
       div.dvlcore_headings {
-        h1 'Heading 1 64/80px'
-        h2 'Heading 2 40/56px'
+        h1 'Heading 1 56/80px'
+        h2 'Heading 2 36/56px'
         h3 'Heading 3 23/32px'
         h4 'Heading 4 16/24px'
         h5 'Heading 5 13/24px'

--- a/vendor/assets/stylesheets/dvl/core/includes.scss
+++ b/vendor/assets/stylesheets/dvl/core/includes.scss
@@ -80,7 +80,7 @@ $radius: 3px !default;
 // TYPOGRAPHY
 
 // Font weights
-$weightLight: 300 !default;
+$weightLight: 200 !default;
 $weightNormal: 400 !default;
 $weightBold: 700 !default;
 
@@ -98,10 +98,10 @@ $ratio: 1.5;
 
 // Font Sizes - Large Screens
 
-$fontSizeH1: 4rem !default; // 64px
+$fontSizeH1: 3.5rem !default; // 56px
 $fontLineHeightH1: (10 * $rhythm) !default; // 80px
 
-$fontSizeH2: 2.5rem !default; // 40px
+$fontSizeH2: 2.25rem !default; // 36px
 $fontLineHeightH2: (7 * $rhythm) !default; // 56px
 
 $fontSizeH3: 1.4375rem !default; // 23px

--- a/vendor/assets/stylesheets/dvl/core/includes.scss
+++ b/vendor/assets/stylesheets/dvl/core/includes.scss
@@ -86,7 +86,7 @@ $weightBold: 700 !default;
 
 // Typography
 $fontFamilyDefault: 'franklin-gothic-urw', 'Franklin Gothic Medium', 'Franklin Gothic', 'ITC Franklin Gothic', 'Helvetica Neue', Arial, sans-serif !default;
-$fontFamilyDisplay: 'source-sans-pro', 'HelveticaNeue-Light', Helvetica, Arial, sans-serif !default;
+$fontFamilyDisplay: 'tablet-gothic-wide', 'HelveticaNeue-Light', Helvetica, Arial, sans-serif !default;
 $fontFamilyMonospace: 'Consolas', 'Monaco', 'Lucida Console', monospace !default;
 $unitlessRhythm: 0.5 !default; // 8px @ 16px root
 $rhythm: $unitlessRhythm * 1rem !default;


### PR DESCRIPTION
I was trying to improve the blog's design, and work on our layout for plain-text pages (like the Terms and Conditions pages). I was having a lot of trouble working with Source Sans Pro. It's too dissimilar to Franklin Gothic to have the refined look I'm going for. So I spent this afternoon switching our display typeface.

I also adjusted the size of our `h1` and `h2` so that the difference should be negligible:

![toggle](https://cloud.githubusercontent.com/assets/1328849/9973137/c7de39a4-5e22-11e5-8b6c-21b12a07c73e.gif)

None of our layouts should be broken by this change, because the type takes up the same amount of space. A quick check across most of our repos confirms this: zero bugs. Still, different typefaces are different, so I've made some optimizations across our other repos.

Also, this looks :100: in IE9.