### PR TITLE
Move form size variables to includes.scss

### DIFF
--- a/vendor/assets/stylesheets/dvl/core/forms.scss
+++ b/vendor/assets/stylesheets/dvl/core/forms.scss
@@ -1,9 +1,5 @@
 // Default form styles
 
-$largeInputHeight: $inputHeight * $ratio;
-$largeInputPadding: $inputPadding * $ratio;
-$smallInputHeight: 2.125rem;
-
 form {
   margin: 0;
 }

--- a/vendor/assets/stylesheets/dvl/core/includes.scss
+++ b/vendor/assets/stylesheets/dvl/core/includes.scss
@@ -178,6 +178,10 @@ $letterspaceSmallest: 0.05rem;
 $inputHeight: $rhythm * 5 !default; // 36px @ 16px root
 $inputPadding: $rhythm !default;
 
+$largeInputHeight: $inputHeight * $ratio;
+$largeInputPadding: $inputPadding * $ratio;
+$smallInputHeight: 2.125rem;
+
 // Grid
 $columnWidth: 8.333%;
 $gutterWidth: $lineHeight;


### PR DESCRIPTION
Allow us to reference the height of small / large form elements in other repos. 