### PR TITLE
Adjust large input sizes, add variables

### DIFF
--- a/vendor/assets/stylesheets/dvl/core/forms.scss
+++ b/vendor/assets/stylesheets/dvl/core/forms.scss
@@ -536,7 +536,7 @@ form {
     }
     .styled_select {
       height: $largeInputHeight;
-      padding: 0 $inputHeight 0 $largeInputPadding;
+      padding: 0 $largeInputHeight 0 $largeInputPadding;
       line-height: $largeInputHeight;
       &:after {
         line-height: 1rem;

--- a/vendor/assets/stylesheets/dvl/core/includes.scss
+++ b/vendor/assets/stylesheets/dvl/core/includes.scss
@@ -178,9 +178,9 @@ $letterspaceSmallest: 0.05rem;
 $inputHeight: $rhythm * 5 !default; // 36px @ 16px root
 $inputPadding: $rhythm !default;
 
-$largeInputHeight: $inputHeight * $ratio;
-$largeInputPadding: $inputPadding * $ratio;
-$smallInputHeight: 2.125rem;
+$largeInputHeight: $rhythm * 7 !default;
+$largeInputPadding: $inputPadding * $ratio !default;
+$smallInputHeight: 2.125rem !default;
 
 // Grid
 $columnWidth: 8.333%;


### PR DESCRIPTION
- Convert large and small input sizes to variables, so they're accessible in other repos (i.e. Screendoor)
- Adjust large input sizes so they're accessible in Screendoor
- Fix awkward padding for large selects:

![screen shot 2015-10-05 at 1 53 32 pm](https://cloud.githubusercontent.com/assets/1328849/10293278/7fafc6d6-6b68-11e5-9fb6-14cb2a422961.png)
