### PR TITLE
IE11 bug fixes, datepicker styles

### DIFF
--- a/app/inputs/datetime_picker_input.rb
+++ b/app/inputs/datetime_picker_input.rb
@@ -16,16 +16,24 @@ class DatetimePickerInput < SimpleForm::Inputs::DateTimeInput
       @builder.hidden_field(attribute_name, input_html_options) +
 
       content_tag(:div, class: 'input_group input_group_date') do
-        tag(:input, type: 'text') +
-        content_tag(:a, class: 'button small') do
-          content_tag :i, class: 'fa fa-calendar' do; end;
+        content_tag(:div, class: 'input_group_input') do
+          tag(:input, type: 'text')
+        end +
+        content_tag(:div, class: 'input_group_append') do
+          content_tag(:a, class: 'button small') do
+            content_tag :i, class: 'fa fa-calendar' do; end;
+          end
         end
       end +
 
       content_tag(:div, class: 'input_group input_group_time') do
-        tag(:input, type: 'text') +
-        content_tag(:a, class: 'button small') do
-          content_tag :i, class: 'fa fa-clock-o' do; end;
+        content_tag(:div, class: 'input_group_input') do
+          tag(:input, type: 'text')
+        end +
+        content_tag(:div, class: 'input_group_append') do
+          content_tag(:a, class: 'button small') do
+            content_tag :i, class: 'fa fa-clock-o' do; end;
+          end
         end
       end +
 

--- a/spec/dummy/app/views/home/forms.rb
+++ b/spec/dummy/app/views/home/forms.rb
@@ -103,16 +103,6 @@ class Views::Home::Forms < Views::Page
       end
     }, hint: 'This component lets you add long answer options, or descriptive text to each option, while imitating the behavior of a native <code>&lt;select&gt;</code>.'.html_safe, sub: true
 
-    docs 'Date and Time Picker', %{
-      simple_form_for :datetime_picker do |f|
-        f.input :deadline,
-                as: :datetime_picker,
-                clear_text: 'Clear'
-      end
-
-      div.js_dt_result '&nbsp;'.html_safe
-    }, sub: true
-
     hr
 
     h3 'States'
@@ -278,30 +268,60 @@ class Views::Home::Forms < Views::Page
 
         f.input :permalink do
           div.input_group {
-            f.input_field :input_group_with_copy,
-                          as: :string,
-                          value: 'http://dobt.forms.fm',
-                          'aria-label' => 'Permalink'
-            a(class: 'button small info',
-              'data-toggle' => 'tooltip',
-              'data-container' => 'body',
-              title: 'Copy URL',
-              'aria-label' => 'Copy URL') {
-              i(class: 'fa fa-copy')
+            div.input_group_input {
+              f.input_field :input_group_with_copy,
+                            as: :string,
+                            value: 'http://dobt.forms.fm',
+                            'aria-label' => 'Permalink'
+            }
+            div.input_group_append {
+              a(class: 'button small info',
+                'data-toggle' => 'tooltip',
+                'data-container' => 'body',
+                title: 'Copy URL',
+                'aria-label' => 'Copy URL') {
+                i(class: 'fa fa-copy')
+              }
             }
           }
         end
 
         f.input :enter_your_age do
-          div.input_group {
-            f.input_field :input_group,
-                          as: :string,
-                          'aria-label' => 'Age'
-            span.input_group_text 'years young'
+          div.input_group.input_group_text {
+            div.input_group_input {
+              f.input_field :input_group,
+                            as: :string,
+                            'aria-label' => 'Age'
+            }
+            div.input_group_append {
+              span 'years young'
+            }
+          }
+        end
+
+        f.input :example_of_prepended_input do
+          div.input_group.input_group_text {
+            div.input_group_prepend {
+              a.button.small {
+                i(class: 'fa fa-eye')
+              }
+            }
+            div.input_group_input {
+              f.input_field :input_group,
+                            as: :string,
+                            'aria-label' => 'Example of prepended button'
+            }
           }
         end
       end
 
+      simple_form_for :datetime_picker do |f|
+        f.input :pick_a_date_and_time,
+                as: :datetime_picker,
+                clear_text: 'Clear'
+      end
+
+      div.js_dt_result '&nbsp;'.html_safe
     }, sub: true
 
     docs 'Filter form', %{

--- a/vendor/assets/javascripts/dvl/components/datetime_picker.coffee
+++ b/vendor/assets/javascripts/dvl/components/datetime_picker.coffee
@@ -22,7 +22,7 @@ class DatetimePicker
       todayHighlight: true
     @$dateInput.datepicker('update', @initDate) if @initDate
     @$dateInput.on 'changeDate clearDate', $.proxy(@update, @)
-    @$dateInput.parent().find('a').click =>
+    @$el.siblings('.input_group_date').find('a').click =>
       @$dateInput.datepicker('show')
 
   initTimeInput: ->
@@ -30,7 +30,7 @@ class DatetimePicker
     @$timeInput.timepicker()
     @$timeInput.timepicker('setTime', @initDate) if @initDate
     @$timeInput.on 'change', $.proxy(@update, @)
-    @$timeInput.parent().find('a').click =>
+    @$el.siblings('.input_group_time').find('a').click =>
       @$timeInput.timepicker('show')
 
   clear: ->

--- a/vendor/assets/javascripts/dvl/vendor/jquery.timepicker.js
+++ b/vendor/assets/javascripts/dvl/vendor/jquery.timepicker.js
@@ -130,7 +130,7 @@ requires jQuery 1.7+
 
       if ((self.offset().top + self.outerHeight(true) + list.outerHeight()) > $(window).height() + $(window).scrollTop()) {
         // position the dropdown on top
-        listOffset.top = self.offset().top - list.outerHeight() + parseInt(list.css('marginTop').replace('px', ''), 10);
+        listOffset.top = self.offset().top - list.outerHeight() + parseInt(list.css('marginTop').replace('px', ''), 10) - 7;
         list.addClass('ui-timepicker-positioned-top');
       } else {
         // put it under the input

--- a/vendor/assets/stylesheets/dvl/core/forms.scss
+++ b/vendor/assets/stylesheets/dvl/core/forms.scss
@@ -143,6 +143,7 @@ textarea {
 input[type="file"] {
   padding: $inputPadding 0;
   max-width: 100%;
+  background: transparent;
 }
 
 // Make checkbox, image, and radio inputs `inline-block` by default
@@ -474,34 +475,78 @@ form {
   position: relative;
   display: table;
   border-collapse: separate;
-  > .button, > .input_group_text {
-    width: 1%;
-    display: table-cell;
-  }
-  > input {
-    display: table-cell;
-    width: 100%;
-  }
-  .button {
-    border-left-width: 0;
-  }
-  :first-child {
-    @include border_right_radius(0);
-  }
-  :last-child {
+}
+
+.input_group_input,
+.input_group_append,
+.input_group_prepend {
+  display: table-cell;
+}
+
+// Remove corner radius for elements not on the edge of .input_groups
+
+.input_group_input input {
+  @include border_right_radius(0);
+  .input_group_prepend + & {
+    @include border_right_radius($radius);
     @include border_left_radius(0);
   }
 }
 
-.input_group_text {
-  display: inline-block;
-  margin: 0;
-  padding-left: $rhythm;
+.input_group_prepend .button {
+  @include border_right_radius(0);
+  border-right-width: 0;
+}
+
+.input_group_append .button {
+  @include border_left_radius(0);
+  border-left-width: 0;
+}
+
+// Restore border radius if no buttons are adjacent
+
+.input_group_text input {
+  border-radius: $radius;
+  border-width: 1px;
+}
+
+.input_group_input {
   width: 100%;
-  color: $darkerGray;
-  text-align: center;
-  line-height: $inputHeight;
-  @include ellipses;
+  input {
+    width: 100%;
+  }
+}
+
+.input_group_append,
+.input_group_prepend {
+  width: 1%;
+  display: table-cell;
+  vertical-align: top;
+  .button {
+    height: $inputHeight;
+    line-height: $rhythm * 4;
+  }
+  span {
+    display: inline-block;
+    margin: 0;
+    width: 100%;
+    color: $darkerGray;
+    text-align: center;
+    line-height: $inputHeight;
+    @include ellipses;
+  }
+}
+
+.input_group_append {
+  span {
+    padding-left: $rhythm;
+  }
+}
+
+.input_group_prepend {
+  span {
+    padding-right: $rhythm;
+  }
 }
 
 form {

--- a/vendor/assets/stylesheets/dvl/datetime_picker.scss
+++ b/vendor/assets/stylesheets/dvl/datetime_picker.scss
@@ -156,21 +156,21 @@ li.ui-timepicker-selected {
     cursor: default;
   }
   .today {
-    background: $secondaryColor;
+    background: rgba($secondaryColor,0.3);
     &:hover,
     &:focus,
     &:active {
-      background: $secondaryColor;
+      background: rgba($secondaryColor,0.3);
       fieldset[disabled] &,
       .open & {
-        background: $secondaryColor;
+        background: rgba($secondaryColor,0.3);
       }
       &[disabled],
       &.disabled {
-        background-color: $secondaryColor;
+        background-color: rgba($secondaryColor,0.3);
         fieldset[disabled] &,
         .open & {
-          background: $secondaryColor;
+          background: rgba($secondaryColor,0.3);
         }
       }
     }


### PR DESCRIPTION
- `.input_group` now uses two parent `div`s for layout, staying consistent with `.alert`.
- Moved the date and time pickers next to other input groups in the style guide.
- Changed a few datepicker styles while I was looking at input groups.

![datepicker_styles](https://cloud.githubusercontent.com/assets/1328849/10705316/e2c687dc-7991-11e5-8884-813d51b91106.png)
