### PR TITLE
Better bold body text

### DIFF
--- a/vendor/assets/stylesheets/dvl/core/includes.scss
+++ b/vendor/assets/stylesheets/dvl/core/includes.scss
@@ -82,7 +82,7 @@ $radius: 3px !default;
 // Font weights
 $weightLight: 200 !default;
 $weightNormal: 400 !default;
-$weightBold: 700 !default;
+$weightBold: 500 !default;
 
 // Typography
 $fontFamilyDefault: 'franklin-gothic-urw', 'Franklin Gothic Medium', 'Franklin Gothic', 'ITC Franklin Gothic', 'Helvetica Neue', Arial, sans-serif !default;

--- a/vendor/assets/stylesheets/dvl/core/typography.scss
+++ b/vendor/assets/stylesheets/dvl/core/typography.scss
@@ -21,6 +21,7 @@ body {
 b,
 strong {
   font-weight: $weightBold;
+  color: $black;
 }
 
 blockquote,


### PR DESCRIPTION
Making bold body text both darker and more lightweight to improve readability while retaining contrast.

![screen shot 2015-10-27 at 7 37 47 pm](https://cloud.githubusercontent.com/assets/1328849/10778339/43b2fadc-7ce2-11e5-8652-a9751576da07.png)


