### PR TITLE
make unordered list styles work for all font sizes

### DIFF
--- a/vendor/assets/stylesheets/dvl/core/lists.scss
+++ b/vendor/assets/stylesheets/dvl/core/lists.scss
@@ -6,8 +6,9 @@
     margin: 0 0 $lineHeight ($rhythm * 3);
     &:before {
       position: absolute;
-      top: $rhythm;
+      top: 50%;
       left: $rhythm * -3;
+      margin-top: - ($rhythm / 2);
       right: 100%;
       content: '';
       width: $rhythm;


### PR DESCRIPTION
tested on Chrome / IE9 / FF