### PR TITLE
always give a max-width to styled selects

### DIFF
--- a/vendor/assets/stylesheets/dvl/core/forms.scss
+++ b/vendor/assets/stylesheets/dvl/core/forms.scss
@@ -561,9 +561,10 @@ form {
   position: relative;
   display: inline-block;
   vertical-align: top;
+  max-width: 100%;
+
   &.auto {
     width: auto;
-    max-width: 100%;
   }
   &.full {
     width: 100%;


### PR DESCRIPTION
noticed this bug in screendoor: http://take.ms/0OV1q

Don't see any downside to this change... @jrubenoff, can you review?