### PR TITLE
Links in flash body should be white

### DIFF
--- a/spec/dummy/app/views/home/components.rb
+++ b/spec/dummy/app/views/home/components.rb
@@ -376,7 +376,7 @@ class Views::Home::Components < Views::Page
           a 'Success notification', href: 'javascript:DvlFlash("success", "You did it!")'
         }
         li {
-          a 'Neutral flash', href: 'javascript:DvlFlash("info", "This is an informational message.")'
+          a 'Neutral flash', href: 'javascript:DvlFlash("info", "This is <a href=#>an informational message</a>.")'
         }
         li {
           a 'Long error notification', href: 'javascript:DvlFlash("error", "Oh dear lord, an error has occurred! I am not sure how to handle a quandary quite like this.")'

--- a/vendor/assets/stylesheets/dvl/components/flashes.scss
+++ b/vendor/assets/stylesheets/dvl/components/flashes.scss
@@ -48,6 +48,24 @@
       top: $rhythm * 2;
       font-size: 1.5rem;
     }
+    a {
+      color: $white;
+      text-decoration: underline;
+      &:hover,
+      &:focus,
+      &:active {
+        color: $white;
+      }
+      &:hover {
+        opacity: 0.95;
+      }
+      &:focus {
+        opacity: 0.8;
+      }
+      &:active {
+        opacity: 0.75;
+      }
+    }
   }
   &.is_visible {
     opacity: 1;


### PR DESCRIPTION
Just fixing stuff I notice as I'm creating dummy content for the video...

Links in the flash body are currently showing up as blue, not white.

Fix:

![screen shot 2015-12-15 at 2 39 18 pm](https://cloud.githubusercontent.com/assets/1328849/11826368/e2a41086-a339-11e5-95fd-2db2df38e766.png)
