### PR TITLE
Allow .button class to be applied to elements like <label>

### DIFF
--- a/vendor/assets/stylesheets/dvl/core/buttons.scss
+++ b/vendor/assets/stylesheets/dvl/core/buttons.scss
@@ -8,6 +8,10 @@
   cursor: pointer;
   border-radius: $radius;
   line-height: $lineHeight;
+  
+  // allow .button to be applied to other elements, e.g. labels
+  font-weight: $weightNormal; 
+  
   @include ellipses;
   @include button_color($lightGray, $bodyFontColor);
 


### PR DESCRIPTION
See https://github.com/dobtco/screendoor-v2/blob/3095d3379ec997c042253488c0e1c5468b7f5ca0/app/assets/stylesheets/shame.scss#L36