### PR TITLE
Add delete confirmations to style guide [BREAKING]

### DIFF
--- a/lib/dvl/core/views/flashes.rb
+++ b/lib/dvl/core/views/flashes.rb
@@ -10,7 +10,7 @@ class Dvl::Core::Views::Flashes < Dvl::Core::Views.base_view_class.constantize
         text = v
       end
 
-      script %{DvlFlash("#{k}", "#{h(text)}", "#{escape_javascript(links)}")}.html_safe
+      script %{Dvl.Flash("#{k}", "#{h(text)}", "#{escape_javascript(links)}")}.html_safe
     end
   end
 

--- a/spec/dummy/app/assets/javascripts/application.js
+++ b/spec/dummy/app/assets/javascripts/application.js
@@ -10,6 +10,7 @@
 // Read Sprockets README (https://github.com/sstephenson/sprockets#sprockets-directives) for details
 // about supported directives.
 //
+//= require dvl/vendor/jquery-ujs
 //= require dvl/core
 //= require dvl/helpers/flash_placeholder
 //= require dvl/helpers/toggle_class
@@ -20,6 +21,10 @@
 //= require dvl/components/splash_footer
 //= require dvl/components/navbar
 //= require dvl/components/dropdown_select
+//= require dvl/components/modal_helper
+//= require dvl/components/confirmations
+//= require dvl/components/popovers
 //= require dvl/datetime_picker
 //= require dvl/vendor/selectize
+//= require dvl/overrides/rails_allow_action
 //= require preview

--- a/spec/dummy/app/assets/stylesheets/application.css.scss
+++ b/spec/dummy/app/assets/stylesheets/application.css.scss
@@ -16,6 +16,8 @@
 @import 'dvl/components/page_subheader';
 @import 'dvl/components/pagination';
 @import 'dvl/components/pagination_compact';
+@import 'dvl/components/popovers';
+@import 'dvl/components/delete_popover';
 @import 'dvl/components/progress';
 @import 'dvl/components/sidebar_data';
 @import 'dvl/components/sidebar_nav';

--- a/spec/dummy/app/assets/stylesheets/preview.scss
+++ b/spec/dummy/app/assets/stylesheets/preview.scss
@@ -27,7 +27,11 @@
     border: 0;
     padding-bottom: 0;
     > h4 {
-      line-height: $inputHeight;
+      @media screen and (min-width: $lapWidth) {
+        position: relative;
+        top: $rhythm;
+        padding-right: 8rem;
+      }
     }
   }
 }
@@ -185,6 +189,23 @@ hr {
   }
   .dropdown:last-child .button {
     margin-right: 0;
+  }
+}
+
+// List in delete confirmations
+
+.delete_list {
+  li {
+    padding: $rhythm 0;
+    @include font_smoothing;
+    max-width: 20rem;
+    border-bottom: 1px solid $gray;
+    &:first-of-type {
+      border-top: 1px solid $gray;
+    }
+  }
+  .subtle_icon {
+    float: right;
   }
 }
 

--- a/spec/dummy/app/views/home/components.rb
+++ b/spec/dummy/app/views/home/components.rb
@@ -373,16 +373,16 @@ class Views::Home::Components < Views::Page
     docs 'Flashes', %{
       ul {
         li {
-          a 'Success notification', href: 'javascript:DvlFlash("success", "You did it!")'
+          a 'Success notification', href: 'javascript:Dvl.Flash("success", "You did it!")'
         }
         li {
-          a 'Neutral flash', href: 'javascript:DvlFlash("info", "This is <a href=#>an informational message</a>.")'
+          a 'Neutral flash', href: 'javascript:Dvl.Flash("info", "This is <a href=#>an informational message</a>.")'
         }
         li {
-          a 'Long error notification', href: 'javascript:DvlFlash("error", "Oh dear lord, an error has occurred! I am not sure how to handle a quandary quite like this.")'
+          a 'Long error notification', href: 'javascript:Dvl.Flash("error", "Oh dear lord, an error has occurred! I am not sure how to handle a quandary quite like this.")'
         }
         li {
-          a 'Neutral with action', href: 'javascript:DvlFlash("info", "Your item was deleted.", "<a href=#>Undo</a>")'
+          a 'Neutral with action', href: 'javascript:Dvl.Flash("info", "Your item was deleted.", "<a href=#>Undo</a>")'
         }
       }
     }
@@ -530,6 +530,50 @@ class Views::Home::Components < Views::Page
         }
       }
     }
+
+    h3 'Delete confirmations'
+
+    p 'Use one of the following patterns to confirm a destructive action.'
+
+    docs "When the Delete button is an icon, show a popover to clarify the user's intent.", %{
+      ul(class: 'delete_list') {
+        li(class: 'js_delete_1') {
+          text 'Project 1'
+          a(class: 'subtle_icon', 'data-confirm' => true, 'data-confirm-with' => 'popover', href: "javascript:$('.js_delete_1').remove()"){
+            i(class: 'fa fa-minus-circle')
+          }
+        }
+        li(class: 'js_delete_2') {
+          text 'Project 2'
+          a(class: 'subtle_icon', 'data-confirm' => 'This is an important record. <strong>It will be destroyed forever.</strong>', 'data-confirm-with' => 'popover', href: "javascript:$('.js_delete_2').remove()"){
+            i(class: 'fa fa-minus-circle')
+          }
+        }
+        li(class: 'js_delete_3') {
+          text 'Project 3'
+          a(class: 'subtle_icon', 'data-confirm' => true, 'data-confirm-with' => 'popover', 'data-confirmation-options' => { 't_delete' => 'Archive' }.to_json, href: "javascript:$('.js_delete_3').remove()"){
+            i(class: 'fa fa-minus-circle')
+          }
+        }
+      }
+    }, sub: true, hint: 'Popovers can contain headers and alternate button text.'
+
+    docs 'When the Delete button contains text, delete the item immediately, and let the user undo the action.', %{
+      li(class: 'js_delete_5') {
+        a(class: 'button_uppercase',
+          href: "javascript: Dvl.Flash('info', 'You deleted the response.', '<a>Undo</a>')") {
+            i(class: 'fa fa-minus-circle')
+            text 'Delete this response'
+          }
+      }
+    }, sub: true, hint: 'The undo is usually implemented server-side.'
+
+
+    docs 'For destructive actions with major consequences, show a confirmation modal.', %{
+      div(class: 'js_delete_4') {
+        a('Archive my project', class: 'button error', 'data-confirm' => true, href: "javascript: Dvl.Flash('info', 'Your project has been archived.')")
+      }
+    }, sub: true
 
     docs 'Tooltips', %{
       %w(top right bottom left).each do |x|

--- a/vendor/assets/javascripts/dvl/components/confirmations.coffee
+++ b/vendor/assets/javascripts/dvl/components/confirmations.coffee
@@ -1,0 +1,94 @@
+Dvl.Confirmations = {}
+
+class Dvl.Confirmations.Popover
+  defaults:
+    t_cancel: 'Cancel'
+    t_delete: 'Delete'
+
+  constructor: ($el, message, cb) ->
+    @$el = $el
+
+    if (instance = @$el.data('popover-confirmation'))
+      return instance.destroy()
+
+    @$el.data('popover-confirmation', @)
+
+    @options = $.extend {}, @defaults, @$el.data('confirmation-options')
+
+    if message
+      wrappedMessage = """
+        <div class='popover_delete_confirmation_message'>
+          #{message}
+        </div>
+      """
+
+    @$el.popover
+      html: true
+      content: """
+        <div class='popover_delete_confirmation'>
+          #{wrappedMessage || ''}
+          <a class='button error js-confirm-delete' href='#'>#{@options.t_delete}</a>
+          <a class='button' href='#'>#{@options.t_cancel}</a>
+        </div>
+      """
+      trigger: 'manual'
+      placement: 'bottom'
+
+    @$el.popover('show')
+
+    $tip = @$el.data('bs.popover').$tip
+
+    $tip.on 'click', '.button', (e) =>
+      cb() if $(e.target).hasClass('js-confirm-delete')
+      @destroy()
+      @$el.popover('destroy')
+
+    $('body').on 'click.delete_confirmation_body', (e) =>
+      unless $.contains($tip[0], e.target) || $.contains(@$el[0], e.target)
+        @destroy()
+
+  destroy: ->
+    @$el.popover('destroy')
+    $('body').off 'click.delete_confirmation_body'
+    @$el.removeData('popover-confirmation')
+
+class Dvl.Confirmations.Modal
+  defaults:
+    t_generic: 'This is a destructive action. Please confirm.'
+    t_title: 'Are you sure?'
+    t_cancel: 'Cancel'
+    t_confirm: 'Confirm'
+
+  constructor: ($el, message, cb) ->
+    @options = $.extend {}, @defaults, $el.data('confirmation-options')
+
+    message ||= @options.t_generic
+
+    $modal = Dvl.Modal.init(
+      Dvl.Modal.getHTML(title: @options.t_title),
+      removeOnClose: true
+    )
+
+    $modal.
+      addClass('modal_confirm').
+      find('.modal_content').
+      append """
+        <div class='modal_body'><p>#{message}</p></div>
+        <div class='modal_footer'>
+          <div class='modal_footer_primary'>
+            <a class='button white' data-dismiss='modal'>
+              #{@options.t_cancel}
+            </a>
+            <button class='button error confirm_button'>#{@options.t_confirm}</button>
+          </div>
+        </div>
+      """
+
+    $modal.one 'click', '.confirm_button', ->
+      cb()
+
+      $modal.
+        modal('hide').
+        remove()
+
+    $modal.find('button.error').focus()

--- a/vendor/assets/javascripts/dvl/components/flashes.coffee
+++ b/vendor/assets/javascripts/dvl/components/flashes.coffee
@@ -1,14 +1,14 @@
 FLASH_ALERT_LENGTH = 3500
 TRANSITION_LENGTH = 300
 
-window.DvlFlashHide = ($flash) ->
+Dvl.FlashHide = ($flash) ->
   $flash.addClass('is_hiding')
 
   $flash.on 'bsTransitionEnd', ->
     $flash.remove()
   .emulateTransitionEnd(TRANSITION_LENGTH)
 
-window.DvlFlash = (flashType, message, linksHTML) ->
+Dvl.Flash = (flashType, message, linksHTML) ->
   # Remove existing flashes
   $('.flash').remove()
 
@@ -20,7 +20,7 @@ window.DvlFlash = (flashType, message, linksHTML) ->
   """)
 
   $flash.on 'click', '.flash_close', ->
-    DvlFlashHide($flash)
+    Dvl.FlashHide($flash)
 
   if linksHTML
     $flash.append("
@@ -37,7 +37,7 @@ window.DvlFlash = (flashType, message, linksHTML) ->
   # Hide flashes automatically unless they have links
   unless linksHTML
     setTimeout ->
-      DvlFlashHide($flash)
+      Dvl.FlashHide($flash)
     , FLASH_ALERT_LENGTH
 
 $(document).on 'page:before-unload', ->

--- a/vendor/assets/javascripts/dvl/components/modal_helper.coffee.erb
+++ b/vendor/assets/javascripts/dvl/components/modal_helper.coffee.erb
@@ -1,0 +1,21 @@
+Dvl.Modal =
+  getHTML: (opts = {}) ->
+    """<%= Dvl::Core::Views::Modal.new(id: ':id', title: ':title') {}.to_html %>""".
+      replace(':id', opts.id || '').
+      replace(':title', opts.title || '')
+
+  init: (html, opts = {}) ->
+    $modal = $(html)
+
+    $modal.appendTo('body')
+
+    unless opts.noShow
+      $modal.modal('show')
+
+    if opts.removeOnClose
+      $modal.on 'hidden.bs.modal', -> $modal.remove()
+
+    if opts.onHide
+      $modal.on 'hide.bs.modal', opts.onHide
+
+    $modal

--- a/vendor/assets/javascripts/dvl/components/popovers.js
+++ b/vendor/assets/javascripts/dvl/components/popovers.js
@@ -1,0 +1,109 @@
+// jshint ignore:start
+/* ========================================================================
+ * Bootstrap: popover.js v3.3.5
+ * http://getbootstrap.com/javascript/#popovers
+ * ========================================================================
+ * Copyright 2011-2015 Twitter, Inc.
+ * Licensed under MIT (https://github.com/twbs/bootstrap/blob/master/LICENSE)
+ * ======================================================================== */
+
+
++function ($) {
+  'use strict';
+
+  // POPOVER PUBLIC CLASS DEFINITION
+  // ===============================
+
+  var Popover = function (element, options) {
+    this.init('popover', element, options)
+  }
+
+  if (!$.fn.tooltip) throw new Error('Popover requires tooltip.js')
+
+  Popover.VERSION  = '3.3.5'
+
+  Popover.DEFAULTS = $.extend({}, $.fn.tooltip.Constructor.DEFAULTS, {
+    placement: 'right',
+    trigger: 'click',
+    content: '',
+    template: '<div class="popover" role="tooltip"><div class="arrow"></div><h3 class="popover_title"></h3><div class="popover_content"></div></div>'
+  })
+
+
+  // NOTE: POPOVER EXTENDS tooltip.js
+  // ================================
+
+  Popover.prototype = $.extend({}, $.fn.tooltip.Constructor.prototype)
+
+  Popover.prototype.constructor = Popover
+
+  Popover.prototype.getDefaults = function () {
+    return Popover.DEFAULTS
+  }
+
+  Popover.prototype.setContent = function () {
+    var $tip    = this.tip()
+    var title   = this.getTitle()
+    var content = this.getContent()
+
+    $tip.find('.popover_title')[this.options.html ? 'html' : 'text'](title)
+    $tip.find('.popover_content').children().detach().end()[ // we use append for html objects to maintain js events
+      this.options.html ? (typeof content == 'string' ? 'html' : 'append') : 'text'
+    ](content)
+
+    $tip.removeClass('fade top bottom left right in')
+
+    // IE8 doesn't accept hiding via the `:empty` pseudo selector, we have to do
+    // this manually by checking the contents.
+    if (!$tip.find('.popover_title').html()) $tip.find('.popover_title').hide()
+  }
+
+  Popover.prototype.hasContent = function () {
+    return this.getTitle() || this.getContent()
+  }
+
+  Popover.prototype.getContent = function () {
+    var $e = this.$element
+    var o  = this.options
+
+    return $e.attr('data-content')
+      || (typeof o.content == 'function' ?
+            o.content.call($e[0]) :
+            o.content)
+  }
+
+  Popover.prototype.arrow = function () {
+    return (this.$arrow = this.$arrow || this.tip().find('.arrow'))
+  }
+
+
+  // POPOVER PLUGIN DEFINITION
+  // =========================
+
+  function Plugin(option) {
+    return this.each(function () {
+      var $this   = $(this)
+      var data    = $this.data('bs.popover')
+      var options = typeof option == 'object' && option
+
+      if (!data && /destroy|hide/.test(option)) return
+      if (!data) $this.data('bs.popover', (data = new Popover(this, options)))
+      if (typeof option == 'string') data[option]()
+    })
+  }
+
+  var old = $.fn.popover
+
+  $.fn.popover             = Plugin
+  $.fn.popover.Constructor = Popover
+
+
+  // POPOVER NO CONFLICT
+  // ===================
+
+  $.fn.popover.noConflict = function () {
+    $.fn.popover = old
+    return this
+  }
+
+}(jQuery);

--- a/vendor/assets/javascripts/dvl/core.js
+++ b/vendor/assets/javascripts/dvl/core.js
@@ -1,3 +1,4 @@
+//= require_self
 //= require dvl/plugins/modernizr_custom
 //= require dvl/core/hacks
 //= require dvl/core/transition
@@ -8,3 +9,5 @@
 //= require dvl/core/buttons
 //= require dvl/core/styled_select
 //= require dvl/core/styled_controls
+
+var Dvl = {};

--- a/vendor/assets/javascripts/dvl/overrides/rails_allow_action.coffee
+++ b/vendor/assets/javascripts/dvl/overrides/rails_allow_action.coffee
@@ -1,0 +1,15 @@
+$.rails.allowAction = ($link) ->
+  if !$link.attr('data-confirm')? || $link.data('confirmed')
+    return true
+
+  cb = ->
+    $link.data('confirmed', true)
+    $link[0].click()
+
+  new Dvl.Confirmations[if $link.data('confirm-with') == 'popover' then 'Popover' else 'Modal'](
+    $link,
+    $link.attr('data-confirm'),
+    cb
+  )
+
+  return false

--- a/vendor/assets/javascripts/dvl/vendor/jquery-ujs.js
+++ b/vendor/assets/javascripts/dvl/vendor/jquery-ujs.js
@@ -1,0 +1,535 @@
+// jshint ignore:start
+(function($, undefined) {
+
+/**
+ * Unobtrusive scripting adapter for jQuery
+ * https://github.com/rails/jquery-ujs
+ *
+ * Requires jQuery 1.8.0 or later.
+ *
+ * Released under the MIT license
+ *
+ */
+
+  // Cut down on the number of issues from people inadvertently including jquery_ujs twice
+  // by detecting and raising an error when it happens.
+  'use strict';
+
+  if ( $.rails !== undefined ) {
+    $.error('jquery-ujs has already been loaded!');
+  }
+
+  // Shorthand to make it a little easier to call public rails functions from within rails.js
+  var rails;
+  var $document = $(document);
+
+  $.rails = rails = {
+    // Link elements bound by jquery-ujs
+    linkClickSelector: 'a[data-confirm], a[data-method], a[data-remote]:not([disabled]), a[data-disable-with], a[data-disable]',
+
+    // Button elements bound by jquery-ujs
+    buttonClickSelector: 'button[data-remote]:not([form]):not(form button), button[data-confirm]:not([form]):not(form button)',
+
+    // Select elements bound by jquery-ujs
+    inputChangeSelector: 'select[data-remote], input[data-remote], textarea[data-remote]',
+
+    // Form elements bound by jquery-ujs
+    formSubmitSelector: 'form',
+
+    // Form input elements bound by jquery-ujs
+    formInputClickSelector: 'form input[type=submit], form input[type=image], form button[type=submit], form button:not([type]), input[type=submit][form], input[type=image][form], button[type=submit][form], button[form]:not([type])',
+
+    // Form input elements disabled during form submission
+    disableSelector: 'input[data-disable-with]:enabled, button[data-disable-with]:enabled, textarea[data-disable-with]:enabled, input[data-disable]:enabled, button[data-disable]:enabled, textarea[data-disable]:enabled',
+
+    // Form input elements re-enabled after form submission
+    enableSelector: 'input[data-disable-with]:disabled, button[data-disable-with]:disabled, textarea[data-disable-with]:disabled, input[data-disable]:disabled, button[data-disable]:disabled, textarea[data-disable]:disabled',
+
+    // Form required input elements
+    requiredInputSelector: 'input[name][required]:not([disabled]), textarea[name][required]:not([disabled])',
+
+    // Form file input elements
+    fileInputSelector: 'input[type=file]:not([disabled])',
+
+    // Link onClick disable selector with possible reenable after remote submission
+    linkDisableSelector: 'a[data-disable-with], a[data-disable]',
+
+    // Button onClick disable selector with possible reenable after remote submission
+    buttonDisableSelector: 'button[data-remote][data-disable-with], button[data-remote][data-disable]',
+
+    // Up-to-date Cross-Site Request Forgery token
+    csrfToken: function() {
+     return $('meta[name=csrf-token]').attr('content');
+    },
+
+    // URL param that must contain the CSRF token
+    csrfParam: function() {
+     return $('meta[name=csrf-param]').attr('content');
+    },
+
+    // Make sure that every Ajax request sends the CSRF token
+    CSRFProtection: function(xhr) {
+      var token = rails.csrfToken();
+      if (token) xhr.setRequestHeader('X-CSRF-Token', token);
+    },
+
+    // Make sure that all forms have actual up-to-date tokens (cached forms contain old ones)
+    refreshCSRFTokens: function(){
+      $('form input[name="' + rails.csrfParam() + '"]').val(rails.csrfToken());
+    },
+
+    // Triggers an event on an element and returns false if the event result is false
+    fire: function(obj, name, data) {
+      var event = $.Event(name);
+      obj.trigger(event, data);
+      return event.result !== false;
+    },
+
+    // Default confirm dialog, may be overridden with custom confirm dialog in $.rails.confirm
+    confirm: function(message) {
+      return confirm(message);
+    },
+
+    // Default ajax function, may be overridden with custom function in $.rails.ajax
+    ajax: function(options) {
+      return $.ajax(options);
+    },
+
+    // Default way to get an element's href. May be overridden at $.rails.href.
+    href: function(element) {
+      return element[0].href;
+    },
+
+    // Checks "data-remote" if true to handle the request through a XHR request.
+    isRemote: function(element) {
+      return element.data('remote') !== undefined && element.data('remote') !== false;
+    },
+
+    // Submits "remote" forms and links with ajax
+    handleRemote: function(element) {
+      var method, url, data, withCredentials, dataType, options;
+
+      if (rails.fire(element, 'ajax:before')) {
+        withCredentials = element.data('with-credentials') || null;
+        dataType = element.data('type') || ($.ajaxSettings && $.ajaxSettings.dataType);
+
+        if (element.is('form')) {
+          method = element.data('ujs:submit-button-formmethod') || element.attr('method');
+          url = element.data('ujs:submit-button-formaction') || element.attr('action');
+          data = $(element[0].elements).serializeArray();
+          // memoized value from clicked submit button
+          var button = element.data('ujs:submit-button');
+          if (button) {
+            data.push(button);
+            element.data('ujs:submit-button', null);
+          }
+          element.data('ujs:submit-button-formmethod', null);
+          element.data('ujs:submit-button-formaction', null);
+        } else if (element.is(rails.inputChangeSelector)) {
+          method = element.data('method');
+          url = element.data('url');
+          data = element.serialize();
+          if (element.data('params')) data = data + '&' + element.data('params');
+        } else if (element.is(rails.buttonClickSelector)) {
+          method = element.data('method') || 'get';
+          url = element.data('url');
+          data = element.serialize();
+          if (element.data('params')) data = data + '&' + element.data('params');
+        } else {
+          method = element.data('method');
+          url = rails.href(element);
+          data = element.data('params') || null;
+        }
+
+        options = {
+          type: method || 'GET', data: data, dataType: dataType,
+          // stopping the "ajax:beforeSend" event will cancel the ajax request
+          beforeSend: function(xhr, settings) {
+            if (settings.dataType === undefined) {
+              xhr.setRequestHeader('accept', '*/*;q=0.5, ' + settings.accepts.script);
+            }
+            if (rails.fire(element, 'ajax:beforeSend', [xhr, settings])) {
+              element.trigger('ajax:send', xhr);
+            } else {
+              return false;
+            }
+          },
+          success: function(data, status, xhr) {
+            element.trigger('ajax:success', [data, status, xhr]);
+          },
+          complete: function(xhr, status) {
+            element.trigger('ajax:complete', [xhr, status]);
+          },
+          error: function(xhr, status, error) {
+            element.trigger('ajax:error', [xhr, status, error]);
+          },
+          crossDomain: rails.isCrossDomain(url)
+        };
+
+        // There is no withCredentials for IE6-8 when
+        // "Enable native XMLHTTP support" is disabled
+        if (withCredentials) {
+          options.xhrFields = {
+            withCredentials: withCredentials
+          };
+        }
+
+        // Only pass url to `ajax` options if not blank
+        if (url) { options.url = url; }
+
+        return rails.ajax(options);
+      } else {
+        return false;
+      }
+    },
+
+    // Determines if the request is a cross domain request.
+    isCrossDomain: function(url) {
+      var originAnchor = document.createElement('a');
+      originAnchor.href = location.href;
+      var urlAnchor = document.createElement('a');
+
+      try {
+        urlAnchor.href = url;
+        // This is a workaround to a IE bug.
+        urlAnchor.href = urlAnchor.href;
+
+        // If URL protocol is false or is a string containing a single colon
+        // *and* host are false, assume it is not a cross-domain request
+        // (should only be the case for IE7 and IE compatibility mode).
+        // Otherwise, evaluate protocol and host of the URL against the origin
+        // protocol and host.
+        return !(((!urlAnchor.protocol || urlAnchor.protocol === ':') && !urlAnchor.host) ||
+          (originAnchor.protocol + '//' + originAnchor.host ===
+            urlAnchor.protocol + '//' + urlAnchor.host));
+      } catch (e) {
+        // If there is an error parsing the URL, assume it is crossDomain.
+        return true;
+      }
+    },
+
+    // Handles "data-method" on links such as:
+    // <a href="/users/5" data-method="delete" rel="nofollow" data-confirm="Are you sure?">Delete</a>
+    handleMethod: function(link) {
+      var href = rails.href(link),
+        method = link.data('method'),
+        target = link.attr('target'),
+        csrfToken = rails.csrfToken(),
+        csrfParam = rails.csrfParam(),
+        form = $('<form method="post" action="' + href + '"></form>'),
+        metadataInput = '<input name="_method" value="' + method + '" type="hidden" />';
+
+      if (csrfParam !== undefined && csrfToken !== undefined && !rails.isCrossDomain(href)) {
+        metadataInput += '<input name="' + csrfParam + '" value="' + csrfToken + '" type="hidden" />';
+      }
+
+      if (target) { form.attr('target', target); }
+
+      form.hide().append(metadataInput).appendTo('body');
+      form.submit();
+    },
+
+    // Helper function that returns form elements that match the specified CSS selector
+    // If form is actually a "form" element this will return associated elements outside the from that have
+    // the html form attribute set
+    formElements: function(form, selector) {
+      return form.is('form') ? $(form[0].elements).filter(selector) : form.find(selector);
+    },
+
+    /* Disables form elements:
+      - Caches element value in 'ujs:enable-with' data store
+      - Replaces element text with value of 'data-disable-with' attribute
+      - Sets disabled property to true
+    */
+    disableFormElements: function(form) {
+      rails.formElements(form, rails.disableSelector).each(function() {
+        rails.disableFormElement($(this));
+      });
+    },
+
+    disableFormElement: function(element) {
+      var method, replacement;
+
+      method = element.is('button') ? 'html' : 'val';
+      replacement = element.data('disable-with');
+
+      if (replacement !== undefined) {
+        element.data('ujs:enable-with', element[method]());
+        element[method](replacement);
+      }
+
+      element.prop('disabled', true);
+      element.data('ujs:disabled', true);
+    },
+
+    /* Re-enables disabled form elements:
+      - Replaces element text with cached value from 'ujs:enable-with' data store (created in `disableFormElements`)
+      - Sets disabled property to false
+    */
+    enableFormElements: function(form) {
+      rails.formElements(form, rails.enableSelector).each(function() {
+        rails.enableFormElement($(this));
+      });
+    },
+
+    enableFormElement: function(element) {
+      var method = element.is('button') ? 'html' : 'val';
+      if (element.data('ujs:enable-with') !== undefined) {
+        element[method](element.data('ujs:enable-with'));
+        element.removeData('ujs:enable-with'); // clean up cache
+      }
+      element.prop('disabled', false);
+      element.removeData('ujs:disabled');
+    },
+
+   /* For 'data-confirm' attribute:
+      - Fires `confirm` event
+      - Shows the confirmation dialog
+      - Fires the `confirm:complete` event
+
+      Returns `true` if no function stops the chain and user chose yes; `false` otherwise.
+      Attaching a handler to the element's `confirm` event that returns a `falsy` value cancels the confirmation dialog.
+      Attaching a handler to the element's `confirm:complete` event that returns a `falsy` value makes this function
+      return false. The `confirm:complete` event is fired whether or not the user answered true or false to the dialog.
+   */
+    allowAction: function(element) {
+      var message = element.data('confirm'),
+          answer = false, callback;
+      if (!message) { return true; }
+
+      if (rails.fire(element, 'confirm')) {
+        try {
+          answer = rails.confirm(message);
+        } catch (e) {
+          (console.error || console.log).call(console, e.stack || e);
+        }
+        callback = rails.fire(element, 'confirm:complete', [answer]);
+      }
+      return answer && callback;
+    },
+
+    // Helper function which checks for blank inputs in a form that match the specified CSS selector
+    blankInputs: function(form, specifiedSelector, nonBlank) {
+      var inputs = $(), input, valueToCheck,
+          selector = specifiedSelector || 'input,textarea',
+          allInputs = form.find(selector);
+
+      allInputs.each(function() {
+        input = $(this);
+        valueToCheck = input.is('input[type=checkbox],input[type=radio]') ? input.is(':checked') : !!input.val();
+        if (valueToCheck === nonBlank) {
+
+          // Don't count unchecked required radio if other radio with same name is checked
+          if (input.is('input[type=radio]') && allInputs.filter('input[type=radio]:checked[name="' + input.attr('name') + '"]').length) {
+            return true; // Skip to next input
+          }
+
+          inputs = inputs.add(input);
+        }
+      });
+      return inputs.length ? inputs : false;
+    },
+
+    // Helper function which checks for non-blank inputs in a form that match the specified CSS selector
+    nonBlankInputs: function(form, specifiedSelector) {
+      return rails.blankInputs(form, specifiedSelector, true); // true specifies nonBlank
+    },
+
+    // Helper function, needed to provide consistent behavior in IE
+    stopEverything: function(e) {
+      $(e.target).trigger('ujs:everythingStopped');
+      e.stopImmediatePropagation();
+      return false;
+    },
+
+    //  Replace element's html with the 'data-disable-with' after storing original html
+    //  and prevent clicking on it
+    disableElement: function(element) {
+      var replacement = element.data('disable-with');
+
+      if (replacement !== undefined) {
+        element.data('ujs:enable-with', element.html()); // store enabled state
+        element.html(replacement);
+      }
+
+      element.bind('click.railsDisable', function(e) { // prevent further clicking
+        return rails.stopEverything(e);
+      });
+      element.data('ujs:disabled', true);
+    },
+
+    // Restore element to its original state which was disabled by 'disableElement' above
+    enableElement: function(element) {
+      if (element.data('ujs:enable-with') !== undefined) {
+        element.html(element.data('ujs:enable-with')); // set to old enabled state
+        element.removeData('ujs:enable-with'); // clean up cache
+      }
+      element.unbind('click.railsDisable'); // enable element
+      element.removeData('ujs:disabled');
+    }
+  };
+
+  if (rails.fire($document, 'rails:attachBindings')) {
+
+    $.ajaxPrefilter(function(options, originalOptions, xhr){ if ( !options.crossDomain ) { rails.CSRFProtection(xhr); }});
+
+    // This event works the same as the load event, except that it fires every
+    // time the page is loaded.
+    //
+    // See https://github.com/rails/jquery-ujs/issues/357
+    // See https://developer.mozilla.org/en-US/docs/Using_Firefox_1.5_caching
+    $(window).on('pageshow.rails', function () {
+      $($.rails.enableSelector).each(function () {
+        var element = $(this);
+
+        if (element.data('ujs:disabled')) {
+          $.rails.enableFormElement(element);
+        }
+      });
+
+      $($.rails.linkDisableSelector).each(function () {
+        var element = $(this);
+
+        if (element.data('ujs:disabled')) {
+          $.rails.enableElement(element);
+        }
+      });
+    });
+
+    $document.delegate(rails.linkDisableSelector, 'ajax:complete', function() {
+        rails.enableElement($(this));
+    });
+
+    $document.delegate(rails.buttonDisableSelector, 'ajax:complete', function() {
+        rails.enableFormElement($(this));
+    });
+
+    $document.delegate(rails.linkClickSelector, 'click.rails', function(e) {
+      var link = $(this), method = link.data('method'), data = link.data('params'), metaClick = e.metaKey || e.ctrlKey;
+      if (!rails.allowAction(link)) return rails.stopEverything(e);
+
+      if (!metaClick && link.is(rails.linkDisableSelector)) rails.disableElement(link);
+
+      if (rails.isRemote(link)) {
+        if (metaClick && (!method || method === 'GET') && !data) { return true; }
+
+        var handleRemote = rails.handleRemote(link);
+        // Response from rails.handleRemote() will either be false or a deferred object promise.
+        if (handleRemote === false) {
+          rails.enableElement(link);
+        } else {
+          handleRemote.fail( function() { rails.enableElement(link); } );
+        }
+        return false;
+
+      } else if (method) {
+        rails.handleMethod(link);
+        return false;
+      }
+    });
+
+    $document.delegate(rails.buttonClickSelector, 'click.rails', function(e) {
+      var button = $(this);
+
+      if (!rails.allowAction(button) || !rails.isRemote(button)) return rails.stopEverything(e);
+
+      if (button.is(rails.buttonDisableSelector)) rails.disableFormElement(button);
+
+      var handleRemote = rails.handleRemote(button);
+      // Response from rails.handleRemote() will either be false or a deferred object promise.
+      if (handleRemote === false) {
+        rails.enableFormElement(button);
+      } else {
+        handleRemote.fail( function() { rails.enableFormElement(button); } );
+      }
+      return false;
+    });
+
+    $document.delegate(rails.inputChangeSelector, 'change.rails', function(e) {
+      var link = $(this);
+      if (!rails.allowAction(link) || !rails.isRemote(link)) return rails.stopEverything(e);
+
+      rails.handleRemote(link);
+      return false;
+    });
+
+    $document.delegate(rails.formSubmitSelector, 'submit.rails', function(e) {
+      var form = $(this),
+        remote = rails.isRemote(form),
+        blankRequiredInputs,
+        nonBlankFileInputs;
+
+      if (!rails.allowAction(form)) return rails.stopEverything(e);
+
+      // Skip other logic when required values are missing or file upload is present
+      if (form.attr('novalidate') === undefined) {
+        if (form.data('ujs:formnovalidate-button') === undefined) {
+          blankRequiredInputs = rails.blankInputs(form, rails.requiredInputSelector, false);
+          if (blankRequiredInputs && rails.fire(form, 'ajax:aborted:required', [blankRequiredInputs])) {
+            return rails.stopEverything(e);
+          }
+        } else {
+          // Clear the formnovalidate in case the next button click is not on a formnovalidate button
+          // Not strictly necessary to do here, since it is also reset on each button click, but just to be certain
+          form.data('ujs:formnovalidate-button', undefined);
+        }
+      }
+
+      if (remote) {
+        nonBlankFileInputs = rails.nonBlankInputs(form, rails.fileInputSelector);
+        if (nonBlankFileInputs) {
+          // Slight timeout so that the submit button gets properly serialized
+          // (make it easy for event handler to serialize form without disabled values)
+          setTimeout(function(){ rails.disableFormElements(form); }, 13);
+          var aborted = rails.fire(form, 'ajax:aborted:file', [nonBlankFileInputs]);
+
+          // Re-enable form elements if event bindings return false (canceling normal form submission)
+          if (!aborted) { setTimeout(function(){ rails.enableFormElements(form); }, 13); }
+
+          return aborted;
+        }
+
+        rails.handleRemote(form);
+        return false;
+
+      } else {
+        // Slight timeout so that the submit button gets properly serialized
+        setTimeout(function(){ rails.disableFormElements(form); }, 13);
+      }
+    });
+
+    $document.delegate(rails.formInputClickSelector, 'click.rails', function(event) {
+      var button = $(this);
+
+      if (!rails.allowAction(button)) return rails.stopEverything(event);
+
+      // Register the pressed submit button
+      var name = button.attr('name'),
+        data = name ? {name:name, value:button.val()} : null;
+
+      var form = button.closest('form');
+      if (form.length === 0) {
+        form = $('#' + button.attr('form'));
+      }
+      form.data('ujs:submit-button', data);
+
+      // Save attributes from button
+      form.data('ujs:formnovalidate-button', button.attr('formnovalidate'));
+      form.data('ujs:submit-button-formaction', button.attr('formaction'));
+      form.data('ujs:submit-button-formmethod', button.attr('formmethod'));
+    });
+
+    $document.delegate(rails.formSubmitSelector, 'ajax:send.rails', function(event) {
+      if (this === event.target) rails.disableFormElements($(this));
+    });
+
+    $document.delegate(rails.formSubmitSelector, 'ajax:complete.rails', function(event) {
+      if (this === event.target) rails.enableFormElements($(this));
+    });
+
+    $(function(){
+      rails.refreshCSRFTokens();
+    });
+  }
+
+})( jQuery );

--- a/vendor/assets/stylesheets/dvl/components/delete_popover.scss
+++ b/vendor/assets/stylesheets/dvl/components/delete_popover.scss
@@ -1,0 +1,17 @@
+.popover_delete_confirmation {
+  .button {
+    display: block;
+    padding-left: 1.5rem;
+    padding-right: 1.5rem;
+
+    &:first-of-type {
+      margin-bottom: $rhythm / 2;
+    }
+  }
+}
+
+.popover_delete_confirmation_message {
+  font-size: 1rem;
+  text-align: center;
+  margin-bottom: $rhythm;
+}

--- a/vendor/assets/stylesheets/dvl/components/popovers.scss
+++ b/vendor/assets/stylesheets/dvl/components/popovers.scss
@@ -1,0 +1,127 @@
+// Popovers
+// For now, only used in delete confirmations.
+
+$arrowBorder: 0.625rem;
+
+.popover {
+  position: absolute;
+  top: 0;
+  left: 0;
+  z-index: $z_popover;
+  display: none;
+  max-width: 15rem;
+  padding: 0;
+  @include font_smoothing;
+  background-color: $white;
+  background-clip: padding-box;
+  border: 1px solid $gray;
+  border-radius: $radius;
+  box-shadow: 0 1px 0 rgba(#000,0.06);
+  opacity: 0;
+  &.in {
+    opacity: 1;
+  }
+  &.top {
+    margin-top: -$rhythm;
+    transform: scale(1,1) translateY(5px);
+  }
+  &.right {
+    margin-left: $rhythm;
+    transform: scale(1,1) translateX(-5px);
+  }
+  &.bottom {
+    margin-top: $rhythm;
+    transform: scale(1,1) translateY(-5px);
+  }
+  &.left {
+    margin-left: -$rhythm;
+    transform: scale(1,1) translateX(5px);
+  }
+}
+
+.popover_content {
+  padding: $rhythm;
+}
+
+// Arrows
+//
+// .arrow is outer, .arrow:after is inner
+
+.popover > .arrow {
+  &,
+  &:after {
+    position: absolute;
+    display: block;
+    width: 0;
+    height: 0;
+    border-color: transparent;
+    border-style: solid;
+  }
+}
+.popover > .arrow {
+  border-width: $arrowBorder;
+}
+.popover > .arrow:after {
+  border-width: $arrowBorder;
+  content: "";
+}
+
+.popover {
+  &.top > .arrow {
+    left: 50%;
+    margin-left: -$arrowBorder;
+    border-bottom-width: 0;
+    border-top-color: $gray;
+    bottom: -$arrowBorder;
+    &:after {
+      content: " ";
+      bottom: 1px;
+      margin-left: -$rhythm;
+      border-bottom-width: 0;
+      border-top-color: $white;
+    }
+  }
+  &.right > .arrow {
+    top: 50%;
+    left: -$arrowBorder;
+    margin-top: -$arrowBorder;
+    border-left-width: 0;
+    border-right-color: $gray;
+    &:after {
+      content: " ";
+      left: 1px;
+      bottom: -$rhythm;
+      border-left-width: 0;
+      border-right-color: $white;
+    }
+  }
+  &.bottom > .arrow {
+    left: 50%;
+    margin-left: -$arrowBorder;
+    border-top-width: 0;
+    border-bottom-color: $gray;
+    top: -$arrowBorder;
+    &:after {
+      content: " ";
+      top: 1px;
+      margin-left: -$arrowBorder;
+      border-top-width: 0;
+      border-bottom-color: $white;
+    }
+  }
+
+  &.left > .arrow {
+    top: 50%;
+    right: -$arrowBorder;
+    margin-top: -$arrowBorder;
+    border-right-width: 0;
+    border-left-color: $gray;
+    &:after {
+      content: " ";
+      right: 1px;
+      border-right-width: 0;
+      border-left-color: $white;
+      bottom: -$rhythm;
+    }
+  }
+}

--- a/vendor/assets/stylesheets/dvl/core/includes.scss
+++ b/vendor/assets/stylesheets/dvl/core/includes.scss
@@ -206,6 +206,7 @@ $navHeight: $rhythm * 7 !default;
 $navBreakpoint: $deskWidth !default;
 
 // Z-index scale
+$z_popover: 590 !default;
 $z_dropdown: 600 !default;
 $z_tooltip: 600 !default;
 $z_navbar: 700 !default;


### PR DESCRIPTION
cf https://github.com/dobtco/dvl-core/pull/101#issuecomment-109139028

I added three kinds of delete confirmations to the "Components" page.

(Also, this PR makes breaking changes to the way our javascript is structured.)

----

## To upgrade:

### New JS

- dvl/components/modal_helper (translate)
- dvl/components/confirmations (translate)
- dvl/components/rails_allow_action

### Namespace changes

- `DvlFlash` -> `Dvl.Flash`
- `DvlFlashHide` -> `Dvl.FlashHide`