### PR TITLE
Standardize placeholder color

### DIFF
--- a/vendor/assets/stylesheets/dvl/core/forms.scss
+++ b/vendor/assets/stylesheets/dvl/core/forms.scss
@@ -4,6 +4,10 @@ form {
   margin: 0;
 }
 
+::placeholder {
+  color: $darkGray;
+}
+
 // 1. Address `margin` set differently in Firefox 4+, Safari 5, & Chrome
 // 2. Correct `font-size` not being inherited in all browsers
 // 3. Correct `font-family` not being inherited in all browsers
@@ -677,7 +681,7 @@ form {
     color: $darkerGray;
   }
   &.is_blank {
-    color: $darkerGray;
+    color: $darkGray;
   }
 }
 


### PR DESCRIPTION
Closes #230 

Input placeholders and `.styled_select.is_blank` will now have the same text color across browsers.

![screen shot 2016-01-22 at 2 15 23 pm](https://cloud.githubusercontent.com/assets/1328849/12524573/ad71ca24-c112-11e5-840a-8edd61a96e79.png)
