### PR TITLE
add word-break: break-word to labels

### DIFF
--- a/vendor/assets/stylesheets/dvl/components/labels.scss
+++ b/vendor/assets/stylesheets/dvl/components/labels.scss
@@ -9,6 +9,10 @@
   font-size: $fontSmaller;
   background-color: $lighterGray;
   color: $darkestGray;
+
+  // For some reason, body { word-wrap: break-word } doesn't affect lablels...
+  // maybe because it's inline-block?
+  word-break: break-word;
 }
 
 .label_error,


### PR DESCRIPTION
closes https://github.com/dobtco/screendoor-v2/issues/3145