### PR TITLE
Tighter letter spacing for headlines

### DIFF
--- a/vendor/assets/stylesheets/dvl/core/includes.scss
+++ b/vendor/assets/stylesheets/dvl/core/includes.scss
@@ -130,6 +130,16 @@ $fontLineHeightH3Mobile: 4 * $rhythm !default; // 32px
 @mixin fontDisplay {
   font-family: $fontFamilyDisplay;
   font-weight: $weightLight;
+  letter-spacing: -0.02em;
+  font-feature-settings: 'tnum';
+}
+
+// Used in addition to fontDefault
+// when overriding fontDisplay
+
+@mixin fontDefaultReset {
+  letter-spacing: 0;
+  font-feature-settings: normal;
 }
 
 @mixin fontH1 {

--- a/vendor/assets/stylesheets/dvl/core/includes.scss
+++ b/vendor/assets/stylesheets/dvl/core/includes.scss
@@ -137,7 +137,7 @@ $fontLineHeightH3Mobile: 4 * $rhythm !default; // 32px
 // Used in addition to fontDefault
 // when overriding fontDisplay
 
-@mixin fontDefaultReset {
+@mixin fontDisplayReset {
   letter-spacing: 0;
   font-feature-settings: normal;
 }


### PR DESCRIPTION
God, this looks so much better:

![screen shot 2016-02-18 at 3 01 16 pm](https://cloud.githubusercontent.com/assets/1328849/13161111/7bfab372-d650-11e5-9c5f-37d7328d0434.png)

- Tighter letter spacing for Tablet Gothic
- Add a `fontDefaultReset` mixin when overriding new `fontDisplay` styles
- Use tabular numbers in headlines to improve readability

Tested in Screendoor, the dashboard and our splash pages. We don't override `h1`s or `h2`s anywhere in Screendoor or the dashboard, so this is a pretty stress-free change!