### PR TITLE
Add the radius back to .filter_form when no button exists

### DIFF
--- a/vendor/assets/stylesheets/dvl/components/filter_form.scss
+++ b/vendor/assets/stylesheets/dvl/components/filter_form.scss
@@ -51,6 +51,7 @@
     }
     input {
       width: 100%;
+      @include border_right_radius($radius);
     }
     // Hide the search button if it exists
     .input_group_append {


### PR DESCRIPTION
Currently:

![screen shot 2016-02-23 at 4 12 57 pm](https://cloud.githubusercontent.com/assets/1328849/13271211/605a2cdc-da48-11e5-8c43-2895397262a8.png)
