### PR TITLE
fieldset pattern for radios, checkboxes

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -7,5 +7,6 @@ group :production do
   gem 'fortitude', github: 'ajb/fortitude'
   gem 'rails'
   gem 'simple_form'
+  gem 'simple_form_legend'
   gem 'thin'
 end

--- a/app/inputs/datetime_picker_input.rb
+++ b/app/inputs/datetime_picker_input.rb
@@ -17,7 +17,7 @@ class DatetimePickerInput < SimpleForm::Inputs::DateTimeInput
 
       content_tag(:div, class: 'input_group input_group_date') do
         content_tag(:div, class: 'input_group_input') do
-          tag(:input, type: 'text')
+          tag(:input, type: 'text', 'aria-label' => I18n.t('dvl_core.datepicker.labels.date'))
         end +
         content_tag(:div, class: 'input_group_append') do
           content_tag(:a, class: 'button small') do
@@ -28,7 +28,7 @@ class DatetimePickerInput < SimpleForm::Inputs::DateTimeInput
 
       content_tag(:div, class: 'input_group input_group_time') do
         content_tag(:div, class: 'input_group_input') do
-          tag(:input, type: 'text')
+          tag(:input, type: 'text', 'aria-label' => I18n.t('dvl_core.datepicker.labels.time'))
         end +
         content_tag(:div, class: 'input_group_append') do
           content_tag(:a, class: 'button small') do

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,3 +7,7 @@ en:
       legal: Legal
       help: Help
       contact: Contact
+    datepicker:
+      labels:
+        date: Choose a date
+        time: Choose a time

--- a/lib/dvl/simple_form_config.rb
+++ b/lib/dvl/simple_form_config.rb
@@ -1,3 +1,12 @@
+module SimpleFormLegend
+  def legend(wrapper_options = nil)
+    label_options = merge_wrapper_options(label_html_options, wrapper_options)
+    template.content_tag(:legend, label_text, label_options)
+  end
+end
+
+SimpleForm::Inputs::Base.send :include, SimpleFormLegend
+
 SimpleForm::Inputs::Base.default_options = {
   # Add the 'control' class to radio/checkbox labels
   item_label_class: 'control'
@@ -20,6 +29,22 @@ SimpleForm.setup do |config|
     end
   end
 
+  config.wrappers :horizontal_fieldset, tag: 'fieldset', class: 'form_item form_item_horiz', error_class: 'error' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.use(:judge) if defined?(Judge)
+
+    b.wrapper tag: 'div', class: 'form_item_horiz_label' do |ba|
+      ba.use :legend
+    end
+
+    b.wrapper tag: 'div', class: 'form_item_horiz_input' do |ba|
+      ba.use :input
+      ba.use :error, wrap_with: { tag: 'span', class: 'form_error' }
+      ba.use :hint,  wrap_with: { tag: 'div', class: 'form_hint' }
+    end
+  end
+
   config.wrappers :vertical, tag: 'div', class: 'form_item form_item_vert', error_class: 'error' do |b|
     b.use :html5
     b.use :placeholder
@@ -27,6 +52,22 @@ SimpleForm.setup do |config|
 
     b.wrapper tag: 'div', class: 'form_item_vert_label' do |ba|
       ba.use :label
+    end
+
+    b.wrapper tag: 'div', class: 'form_item_vert_input' do |ba|
+      ba.use :input
+      ba.use :error, wrap_with: { tag: 'span', class: 'form_error' }
+      ba.use :hint,  wrap_with: { tag: 'div', class: 'form_hint' }
+    end
+  end
+
+  config.wrappers :vertical_fieldset, tag: 'fieldset', class: 'form_item form_item_vert', error_class: 'error' do |b|
+    b.use :html5
+    b.use :placeholder
+    b.use(:judge) if defined?(Judge)
+
+    b.wrapper tag: 'div', class: 'form_item_vert_label' do |ba|
+      ba.use :legend
     end
 
     b.wrapper tag: 'div', class: 'form_item_vert_input' do |ba|

--- a/lib/dvl/simple_form_config.rb
+++ b/lib/dvl/simple_form_config.rb
@@ -1,81 +1,35 @@
-module SimpleFormLegend
-  def legend(wrapper_options = nil)
-    label_options = merge_wrapper_options(label_html_options, wrapper_options)
-    template.content_tag(:legend, label_text, label_options)
-  end
-end
-
-SimpleForm::Inputs::Base.send :include, SimpleFormLegend
-
 SimpleForm::Inputs::Base.default_options = {
   # Add the 'control' class to radio/checkbox labels
   item_label_class: 'control'
 }
 
 SimpleForm.setup do |config|
-  config.wrappers :horizontal, tag: 'div', class: 'form_item form_item_horiz', error_class: 'error' do |b|
-    b.use :html5
-    b.use :placeholder
-    b.use(:judge) if defined?(Judge)
+  def generate_wrapper(config, name, tag, mod)
+    config.wrappers name, tag: tag, class: "form_item form_item_#{mod}", error_class: 'error' do |b|
+      b.use :html5
+      b.use :placeholder
+      b.use(:judge) if defined?(Judge)
 
-    b.wrapper tag: 'div', class: 'form_item_horiz_label' do |ba|
-      ba.use :label
-    end
+      b.wrapper tag: 'div', class: "form_item_#{mod}_label" do |ba|
+        if tag == :div
+          ba.use :label
+        elsif tag == :fieldset
+          ba.use :legend
+        end
+      end
 
-    b.wrapper tag: 'div', class: 'form_item_horiz_input' do |ba|
-      ba.use :input
-      ba.use :error, wrap_with: { tag: 'span', class: 'form_error' }
-      ba.use :hint,  wrap_with: { tag: 'div', class: 'form_hint' }
-    end
-  end
-
-  config.wrappers :horizontal_fieldset, tag: 'fieldset', class: 'form_item form_item_horiz', error_class: 'error' do |b|
-    b.use :html5
-    b.use :placeholder
-    b.use(:judge) if defined?(Judge)
-
-    b.wrapper tag: 'div', class: 'form_item_horiz_label' do |ba|
-      ba.use :legend
-    end
-
-    b.wrapper tag: 'div', class: 'form_item_horiz_input' do |ba|
-      ba.use :input
-      ba.use :error, wrap_with: { tag: 'span', class: 'form_error' }
-      ba.use :hint,  wrap_with: { tag: 'div', class: 'form_hint' }
+      b.wrapper tag: 'div', class: "form_item_#{mod}_input" do |ba|
+        ba.use :input
+        ba.use :error, wrap_with: { tag: 'span', class: 'form_error' }
+        ba.use :hint,  wrap_with: { tag: 'div', class: 'form_hint' }
+      end
     end
   end
 
-  config.wrappers :vertical, tag: 'div', class: 'form_item form_item_vert', error_class: 'error' do |b|
-    b.use :html5
-    b.use :placeholder
-    b.use(:judge) if defined?(Judge)
-
-    b.wrapper tag: 'div', class: 'form_item_vert_label' do |ba|
-      ba.use :label
-    end
-
-    b.wrapper tag: 'div', class: 'form_item_vert_input' do |ba|
-      ba.use :input
-      ba.use :error, wrap_with: { tag: 'span', class: 'form_error' }
-      ba.use :hint,  wrap_with: { tag: 'div', class: 'form_hint' }
-    end
-  end
-
-  config.wrappers :vertical_fieldset, tag: 'fieldset', class: 'form_item form_item_vert', error_class: 'error' do |b|
-    b.use :html5
-    b.use :placeholder
-    b.use(:judge) if defined?(Judge)
-
-    b.wrapper tag: 'div', class: 'form_item_vert_label' do |ba|
-      ba.use :legend
-    end
-
-    b.wrapper tag: 'div', class: 'form_item_vert_input' do |ba|
-      ba.use :input
-      ba.use :error, wrap_with: { tag: 'span', class: 'form_error' }
-      ba.use :hint,  wrap_with: { tag: 'div', class: 'form_hint' }
-    end
-  end
+  generate_wrapper config, :horizontal, :div, 'horiz'
+  generate_wrapper config, :horizontal_fieldset, :fieldset, 'horiz'
+  generate_wrapper config, :vertical, :div, 'vert'
+  generate_wrapper config, :vertical_fieldset, :fieldset, 'vert'
 
   config.default_wrapper = :vertical
 

--- a/spec/dummy/app/assets/javascripts/preview.coffee
+++ b/spec/dummy/app/assets/javascripts/preview.coffee
@@ -8,9 +8,6 @@ $ ->
 $(document).on 'click', '.docs_toggle_button', ->
   $(@).closest('.docs_item').find('.docs_code').toggle()
 
-$(document).on 'update.dtpicker', '#datetime_picker_pick_a_date_and_time', (_, ts) ->
-  $('.js_dt_result').html(ts || 'none')
-
 $(document).on 'ajax:beforeSend', '.delete_list .icon_secondary', ->
   $(@).closest('li').remove()
 

--- a/spec/dummy/app/views/home/forms.rb
+++ b/spec/dummy/app/views/home/forms.rb
@@ -360,7 +360,8 @@ class Views::Home::Forms < Views::Page
       simple_form_for :datetime_picker do |f|
         f.input :pick_a_date_and_time,
                 as: :datetime_picker,
-                clear_text: 'Clear'
+                clear_text: 'Clear',
+                wrapper: :vertical_fieldset
       end
 
       div {

--- a/spec/dummy/app/views/home/forms.rb
+++ b/spec/dummy/app/views/home/forms.rb
@@ -468,7 +468,7 @@ class Views::Home::Forms < Views::Page
 
     docs 'Button sizes', %{
       div(class: 'dvlcore_button_array') {
-        a 'Normal', class: 'button large'
+        a 'Large', class: 'button large'
         a 'Normal', class: 'button'
         a 'Small', class: 'button small'
         a 'Mini', class: 'button mini'

--- a/spec/dummy/app/views/home/forms.rb
+++ b/spec/dummy/app/views/home/forms.rb
@@ -21,19 +21,22 @@ class Views::Home::Forms < Views::Page
                 as: :radio_buttons,
                 collection: ['Enthusiastic', 'Indifferent', 'Antagonistic'],
                 label: 'What are your thoughts on the Bilderberg Group?',
-                checked: 'Indifferent'
+                checked: 'Indifferent',
+                wrapper: :vertical_fieldset
 
         f.input :checkbox,
                 as: :check_boxes,
                 collection: ['Animal', 'Augmented organism', 'Gaseous mass', 'Human', 'Robot', 'An unclassifiable entity, perhaps capable of emotion and rational thought, perhaps in possession of a soul, perhaps with the critical faculties necessary to appreciate a fine wine. Why bother to put a label on it?'],
                 label: 'Which of the group(s) below most accurately represent you?',
-                checked: 'Human'
+                checked: 'Human',
+                wrapper: :vertical_fieldset
 
         f.input :boolean,
                 as: :boolean,
                 label: 'Do you agree to the Terms of Service?',
                 inline_label: 'Yes.',
-                hint: "Checkbox fields can contain a single answer option where appropriate.".html_safe
+                hint: "Checkbox fields can contain a single answer option where appropriate.".html_safe,
+                wrapper: :vertical_fieldset
 
         label(class: 'control control_minus') {
           input type: 'checkbox', checked: true
@@ -136,14 +139,16 @@ class Views::Home::Forms < Views::Page
                 label: 'Is the sky blue?',
                 collection: ['Yes', 'No'],
                 checked: 'Yes',
-                disabled: true
+                disabled: true,
+                wrapper: :vertical_fieldset
 
         f.input :disabled_checkbox,
                 as: :check_boxes,
                 label: 'Which countries border the United States?',
                 collection: ['Canada', 'Mexico', 'Australia'],
                 checked: ['Canada', 'Mexico'],
-                disabled: true
+                disabled: true,
+                wrapper: :vertical_fieldset
 
         f.input :select,
                 as: :select,
@@ -265,7 +270,8 @@ class Views::Home::Forms < Views::Page
                 as: :radio_buttons,
                 collection: ['Enthusiastic', 'Indifferent', 'Antagonistic'],
                 label: 'What are your thoughts on the Bilderberg Group?',
-                checked: 'Indifferent'
+                checked: 'Indifferent',
+                wrapper: :horizontal_fieldset
 
         f.input :text,
                 as: :text,

--- a/spec/dummy/app/views/home/forms.rb
+++ b/spec/dummy/app/views/home/forms.rb
@@ -363,11 +363,6 @@ class Views::Home::Forms < Views::Page
                 clear_text: 'Clear',
                 wrapper: :vertical_fieldset
       end
-
-      div {
-        text 'Date chosen: '
-        span 'none', class: 'js_dt_result'
-      }
     }, sub: true
 
     docs 'Filter form', %{

--- a/spec/dummy/config/application.rb
+++ b/spec/dummy/config/application.rb
@@ -19,6 +19,7 @@ end
 Bundler.require(*Rails.groups)
 
 require 'simple_form'
+require 'simple_form_legend'
 require 'autoprefixer-rails'
 require 'sass'
 
@@ -56,4 +57,3 @@ module Dummy
     config.autoload_paths += %W(#{config.root}/lib)
   end
 end
-

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,6 +9,7 @@ require 'capybara-webkit'
 require 'active_support/all'
 require 'dvl/core'
 require 'simple_form'
+require 'simple_form_legend'
 require 'percy/capybara'
 require 'percy/capybara/rspec'
 

--- a/vendor/assets/stylesheets/dvl/core/forms.scss
+++ b/vendor/assets/stylesheets/dvl/core/forms.scss
@@ -99,7 +99,7 @@ textarea,
   color: $darkestGray;
 }
 
-label {
+label, legend {
   color: $darkerGray;
   @include font_smoothing;
 }
@@ -219,7 +219,7 @@ textarea {
   resize: vertical; // 3
 }
 
-label.required > abbr {
+.required > abbr {
   color: $errorColor;
   font-size: $fontSmaller;
   position: relative;


### PR DESCRIPTION
Alternative to #243.

As you can see, the only change in our markup is to add `wrapper: :vertical_fieldset` or `wrapper: :horizontal_fieldset` to the input. Here's a screenshot of the generated markup: http://take.ms/f40Z5.

@jrubenoff: Let me know what you think?

I didn't include the date/time picker in the PR, since it's a separate concern. I'll get to it shortly, though.