### PR TITLE
add `aria-label` to all icons without equivalent text content

### DIFF
--- a/app/inputs/datetime_picker_input.rb
+++ b/app/inputs/datetime_picker_input.rb
@@ -21,7 +21,7 @@ class DatetimePickerInput < SimpleForm::Inputs::DateTimeInput
         end +
         content_tag(:div, class: 'input_group_append') do
           content_tag(:a, class: 'button small') do
-            content_tag :i, class: 'fa fa-calendar' do; end;
+            content_tag :i, class: 'fa fa-calendar', 'aria-label' => I18n.t('dvl_core.datepicker.labels.date') do; end;
           end
         end
       end +
@@ -32,7 +32,7 @@ class DatetimePickerInput < SimpleForm::Inputs::DateTimeInput
         end +
         content_tag(:div, class: 'input_group_append') do
           content_tag(:a, class: 'button small') do
-            content_tag :i, class: 'fa fa-clock-o' do; end;
+            content_tag :i, class: 'fa fa-clock-o', 'aria-label' => I18n.t('dvl_core.datepicker.labels.time') do; end;
           end
         end
       end +

--- a/spec/dummy/app/views/base.rb
+++ b/spec/dummy/app/views/base.rb
@@ -15,4 +15,11 @@ class Views::Base < Fortitude::Widget
     transform: :output_return_value,
     output_yielded_methods: SIMPLE_FORM_FOR_YIELDED_METHODS_TO_OUTPUT
   )
+
+  # Don't emit content_tag
+  helper :content_tag
+
+  def icon(x, opts = {})
+    content_tag(:i, opts.merge(class: "fa fa-#{x} #{opts[:class]}")) { }
+  end
 end

--- a/spec/dummy/app/views/home/components.rb
+++ b/spec/dummy/app/views/home/components.rb
@@ -25,7 +25,7 @@ class Views::Home::Components < Views::Page
                 a(href: 'mailto:support@dobt.co') {
                   span 'Contact support&hellip;'.html_safe, class: 'drop_rt_item'
                   span(
-                    icon('external-link'),
+                    icon('external-link', 'aria-label' => 'Opens in email client'),
                     class: 'drop_rt_arrow'
                   )
                 }

--- a/spec/dummy/app/views/home/components.rb
+++ b/spec/dummy/app/views/home/components.rb
@@ -24,7 +24,10 @@ class Views::Home::Components < Views::Page
               li {
                 a(href: 'mailto:support@dobt.co') {
                   span 'Contact support&hellip;'.html_safe, class: 'drop_rt_item'
-                  span(class: 'drop_rt_arrow') { i(class: 'fa fa-external-link') }
+                  span(
+                    icon('external-link'),
+                    class: 'drop_rt_arrow'
+                  )
                 }
               }
             }
@@ -74,21 +77,21 @@ class Views::Home::Components < Views::Page
             ul(class: 'dropdown_body') {
               li {
                 a(href: '#') {
-                  span(class: 'drop_master') { i(class: 'fa fa-envelope') }
+                  span(icon('envelope'), class: 'drop_master')
                   span 'Send a message', class: 'drop_detail'
                 }
               }
 
               li {
                 a(href: '#') {
-                  span(class: 'drop_master') { i(class: 'fa fa-pencil') }
+                  span(icon('pencil'), class: 'drop_master')
                   span 'Edit', class: 'drop_detail'
                 }
               }
 
               li {
                 a(href: '#') {
-                  span(class: 'drop_master') { i(class: 'fa fa-minus-circle') }
+                  span(icon('minus-circle'), class: 'drop_master')
                   span 'Delete', class: 'drop_detail'
                 }
               }
@@ -201,7 +204,7 @@ class Views::Home::Components < Views::Page
                 a(
                   'data-dropdown-filter-action' => true
                 ) {
-                  span(class: 'drop_master') { i(class: 'fa fa-minus-circle') }
+                  span(icon('minus-circle'), class: 'drop_master')
                   span 'Clear selection', class: 'drop_detail'
                 }
               }
@@ -266,7 +269,7 @@ class Views::Home::Components < Views::Page
             ul(class: 'dropdown_body') {
               li(class: 'dropdown_loading') {
                 span {
-                  i(class: 'fa fa-spin fa-refresh')
+                  i(class: 'fa fa-spin fa-refresh', 'aria-label' => 'Loading...')
                 }
               }
             }
@@ -539,21 +542,15 @@ class Views::Home::Components < Views::Page
       ul(class: 'delete_list') {
         li(class: 'js_delete_1') {
           text 'Project 1'
-          a(class: 'icon_secondary', 'data-confirm' => true, 'data-confirm-with' => 'popover', href: '/delete', 'data-method' => 'delete', 'data-remote' => true) {
-            i(class: 'fa fa-minus-circle')
-          }
+          a(icon('minus-circle', 'aria-label' => 'Delete'), class: 'icon_secondary', 'data-confirm' => true, 'data-confirm-with' => 'popover', href: '/delete', 'data-method' => 'delete', 'data-remote' => true)
         }
         li(class: 'js_delete_2') {
           text 'Project 2'
-          a(class: 'icon_secondary', 'data-confirm' => 'This is an important record. <strong>It will be destroyed forever.</strong>', 'data-confirm-with' => 'popover', href: '/delete', 'data-method' => 'delete', 'data-remote' => true) {
-            i(class: 'fa fa-minus-circle')
-          }
+          a(icon('minus-circle', 'aria-label' => 'Delete'), class: 'icon_secondary', 'data-confirm' => 'This is an important record. <strong>It will be destroyed forever.</strong>', 'data-confirm-with' => 'popover', href: '/delete', 'data-method' => 'delete', 'data-remote' => true)
         }
         li(class: 'js_delete_3') {
           text 'Project 3'
-          a(class: 'icon_secondary', 'data-confirm' => true, 'data-confirm-with' => 'popover', 'data-confirmation-options' => { 't_delete' => 'Archive' }.to_json, href: '/delete', 'data-method' => 'delete', 'data-remote' => true) {
-            i(class: 'fa fa-minus-circle')
-          }
+          a(icon('minus-circle', 'aria-label' => 'Delete'), class: 'icon_secondary', 'data-confirm' => true, 'data-confirm-with' => 'popover', 'data-confirmation-options' => { 't_delete' => 'Archive' }.to_json, href: '/delete', 'data-method' => 'delete', 'data-remote' => true)
         }
       }
     }, sub: true, hint: 'Popovers can contain headers and alternate button text.'
@@ -562,7 +559,7 @@ class Views::Home::Components < Views::Page
       li(class: 'js_delete_5') {
         a(class: 'button_uppercase',
           href: "javascript: Dvl.Flash('info', 'You deleted the response.', '<a>Undo</a>')") {
-            i(class: 'fa fa-minus-circle')
+            text icon('minus-circle')
             text 'Delete this response'
           }
       }

--- a/spec/dummy/app/views/home/forms.rb
+++ b/spec/dummy/app/views/home/forms.rb
@@ -377,7 +377,7 @@ class Views::Home::Forms < Views::Page
         div(class: 'input_group_input') {
           i(class: 'fa fa-search')
           a(href: '#') {
-            i(class: 'fa fa-times-circle filter_form_icon_right')
+            i(class: 'fa fa-times-circle filter_form_icon_right', 'aria-label' => 'Clear search')
           }
           input(type: 'text', placeholder: 'Search your projects', 'aria-label' => 'Search your projects')
         }

--- a/spec/dummy/app/views/home/headers.rb
+++ b/spec/dummy/app/views/home/headers.rb
@@ -10,7 +10,7 @@ class Views::Home::Headers < Views::Page
         h2 {
           text 'Sales Leads'
           a(class: 'button subtle mini') {
-            i(class: 'fa fa-pencil')
+            i(class: 'fa fa-pencil', 'aria-label' => 'Edit title')
           }
         }
         div(class: 'page_header_secondary') {
@@ -201,7 +201,7 @@ class Views::Home::Headers < Views::Page
           div(class: 'input_group_input') {
             i(class: 'fa fa-search')
             a(href: '#') {
-              i(class: 'fa fa-times-circle filter_form_icon_right')
+              i(class: 'fa fa-times-circle filter_form_icon_right', 'aria-label' => 'Clear search')
             }
             input(type: 'text', placeholder: 'Search your projects')
           }
@@ -219,7 +219,7 @@ class Views::Home::Headers < Views::Page
           div(class: 'input_group_input') {
             i(class: 'fa fa-search')
             a(href: '#') {
-              i(class: 'fa fa-times-circle filter_form_icon_right')
+              i(class: 'fa fa-times-circle filter_form_icon_right', 'aria-label' => 'Clear search')
             }
             input(type: 'text', placeholder: 'Search your projects', value: 'Innovation Challenge')
           }

--- a/spec/dummy/app/views/home/navigation.rb
+++ b/spec/dummy/app/views/home/navigation.rb
@@ -11,7 +11,7 @@ class Views::Home::Navigation < Views::Page
         div(class: 'container') {
           div(class: 'navbar_header') {
             a 'DOBT Style Guide', class: 'navbar_brand', href: '#'
-            a "<i class='fa fa-reorder'></i>".html_safe, class: 'navbar_toggle'
+            a(icon('reorder', 'aria-label' => 'Expand navigation'), class: 'navbar_toggle')
           }
 
           div(class: 'navbar_content_wrapper') {
@@ -36,7 +36,7 @@ class Views::Home::Navigation < Views::Page
             a(class: 'navbar_brand', href: '#') {
               img src: 'https://www.dobt.co/img/dobt_logo.png'
             }
-            a "<i class='fa fa-reorder'></i>".html_safe, class: 'navbar_toggle'
+            a(icon('reorder', 'aria-label' => 'Expand navigation'), class: 'navbar_toggle')
           }
 
           div(class: 'navbar_content_wrapper') {
@@ -59,7 +59,7 @@ class Views::Home::Navigation < Views::Page
                 li {
                   a {
                     span(class: 'navbar_full_i') {
-                      i(class: 'fa fa-bolt navbar_icon')
+                      i(class: 'fa fa-bolt navbar_icon', 'aria-label' => 'Notifications')
                     }
                     span(class: 'navbar_collapsed_i') {
                       text 'Notifications'
@@ -74,7 +74,7 @@ class Views::Home::Navigation < Views::Page
                     href: '#'
                   ) {
                     span(class: 'navbar_full_i') {
-                      i(class: 'fa fa-refresh navbar_icon')
+                      i(class: 'fa fa-refresh navbar_icon', 'aria-label' => 'Loading')
                     }
                     span(class: 'navbar_collapsed_i') {
                       text 'Loading State'
@@ -86,7 +86,7 @@ class Views::Home::Navigation < Views::Page
                     ul(class: 'dropdown_body') {
                       li(class: 'dropdown_loading') {
                         span {
-                          i(class: 'fa fa-spin fa-refresh')
+                          i(class: 'fa fa-spin fa-refresh', 'aria-label' => 'Loading')
                         }
                       }
                     }


### PR DESCRIPTION
closes #263. we'll still need to do this inside Screendoor, though.

- aria-label seems preferable to another element. i even tested it in
voiceover, and it's perfect.
- Our current ruby pattern supports this already