### PR TITLE
Set dropdown headers to proper line-height

### DIFF
--- a/vendor/assets/stylesheets/dvl/components/dropdowns.scss
+++ b/vendor/assets/stylesheets/dvl/components/dropdowns.scss
@@ -60,6 +60,7 @@
     color: $darkestGray;
     padding: $rhythm $rhythm * 2;
     font-size: $fontSmaller;
+    line-height: $unitlessLineHeight;
     text-transform: uppercase;
     letter-spacing: $letterspaceSmaller;
     margin: 0;

--- a/vendor/assets/stylesheets/dvl/components/dropdowns.scss
+++ b/vendor/assets/stylesheets/dvl/components/dropdowns.scss
@@ -60,7 +60,7 @@
     color: $darkestGray;
     padding: $rhythm $rhythm * 2;
     font-size: $fontSmaller;
-    line-height: $unitlessLineHeight;
+    line-height: $lineHeight;
     text-transform: uppercase;
     letter-spacing: $letterspaceSmaller;
     margin: 0;


### PR DESCRIPTION
Fixing this bug:

![screen shot 2016-06-10 at 11 52 01 am](https://cloud.githubusercontent.com/assets/1328849/15975312/c61b85bc-2f01-11e6-9f86-66d4fef44616.png)
