### PR TITLE
More visually lightweight disabled inputs

### DIFF
--- a/vendor/assets/stylesheets/dvl/core/forms.scss
+++ b/vendor/assets/stylesheets/dvl/core/forms.scss
@@ -83,7 +83,7 @@ textarea {
     border-color: $primaryColor;
   }
   &[readonly], &[disabled] {
-    border-color: #ccc;
+    border-color: $lighterGray;
     color: $darkerGray;
     @include font_smoothing;
     background-color: $lightestGray;
@@ -658,7 +658,7 @@ form {
     &[disabled] {
       + div {
         background: $lightestGray;
-        border-color: $gray;
+        border-color: $lighterGray;
         &:after {
           color: #888;
         }


### PR DESCRIPTION
Just changing the border color...

![screen shot 2016-06-15 at 4 52 28 pm](https://cloud.githubusercontent.com/assets/1328849/16101337/964b427a-3319-11e6-8d5a-c441bbb0a3c7.png)

...for the profile "email" and "password" inputs.