### PR TITLE
add left border to disabled input group buttons

### DIFF
--- a/spec/dummy/app/views/home/forms.rb
+++ b/spec/dummy/app/views/home/forms.rb
@@ -328,12 +328,13 @@ class Views::Home::Forms < Views::Page
       simple_form_for :input_groups do |f|
 
         f.input :permalink do
-          div(class: 'input_group') {
+          div(class: 'input_group input_group_disabled') {
             div(class: 'input_group_input') {
               f.input_field :input_group_with_copy,
                             as: :string,
                             value: 'http://dobt.forms.fm',
-                            'aria-label' => 'Permalink'
+                            'aria-label' => 'Permalink',
+                            disabled: true
             }
             div(class: 'input_group_append') {
               a(class: 'button small info',
@@ -377,21 +378,6 @@ class Views::Home::Forms < Views::Page
                 'aria-label' => 'Copy URL') {
                 i(class: 'fa fa-copy')
               }
-            }
-          }
-        end
-
-        f.input :example_of_prepended_input do
-          div(class: 'input_group input_group_text') {
-            div(class: 'input_group_prepend') {
-              a(class: 'button small') {
-                i(class: 'fa fa-eye')
-              }
-            }
-            div(class: 'input_group_input') {
-              f.input_field :input_group,
-                            as: :string,
-                            'aria-label' => 'Example of prepended button'
             }
           }
         end

--- a/vendor/assets/stylesheets/dvl/core/forms.scss
+++ b/vendor/assets/stylesheets/dvl/core/forms.scss
@@ -501,8 +501,7 @@ form {
 }
 
 .input_group_input,
-.input_group_append,
-.input_group_prepend {
+.input_group_append {
   display: table-cell;
 }
 
@@ -510,22 +509,16 @@ form {
 
 .input_group_input input {
   @include border_right_radius(0);
-  .input_group_prepend + & {
-    @include border_right_radius($radius);
-    @include border_left_radius(0);
-  }
-}
-
-.input_group_prepend .button,
-.input_group_prepend .button:hover {
-  @include border_right_radius(0);
-  border-right-width: 0;
 }
 
 .input_group_append .button,
 .input_group_append .button:hover {
   @include border_left_radius(0);
   border-left-width: 0;
+
+  .input_group_disabled & {
+    border-left-width: 1px;
+  }
 }
 
 // Restore border radius if no buttons are adjacent
@@ -542,8 +535,7 @@ form {
   }
 }
 
-.input_group_append,
-.input_group_prepend {
+.input_group_append {
   width: 1%;
   display: table-cell;
   vertical-align: top;
@@ -570,12 +562,6 @@ form {
 .input_group_append {
   span {
     padding-left: $rhythm;
-  }
-}
-
-.input_group_prepend {
-  span {
-    padding-right: $rhythm;
   }
 }
 


### PR DESCRIPTION
closes #278

Also, I removed `input_group_prepend` because:

1. it would make implementing this a whole lot harder, and
2. it's not used anywhere!