### PR TITLE
Style icons in .blank_slate_alternative

### DIFF
--- a/vendor/assets/stylesheets/dvl/components/blank_slate.scss
+++ b/vendor/assets/stylesheets/dvl/components/blank_slate.scss
@@ -38,6 +38,10 @@
 .blank_slate_alternative {
   font-size: $fontSmaller;
   margin-top: $rhythm / 2;
+  i {
+    font-size: $fontSmaller;
+    margin-right: $rhythm;
+  }
 }
 
 


### PR DESCRIPTION
Fix issues like these, from dobtco/screendoor-v2#4311:

![](https://cloud.githubusercontent.com/assets/1269308/20323288/e9166978-ab30-11e6-9efc-5d769474aaa7.png)
