### PR TITLE
Adds href parameters to footer widget.

### DIFF
--- a/lib/dvl/core/views/footer.rb
+++ b/lib/dvl/core/views/footer.rb
@@ -2,7 +2,13 @@ class Dvl::Core::Views::Footer < Dvl::Core::Views.base_view_class.constantize
   needs :application_name,
         append: nil,
         prepend_links: nil,
-        append_links: nil
+        append_links: nil,
+        hrefs: {
+          status: 'http://status.dobt.co',
+          legal: 'https://www.dobt.co/terms/',
+          help: 'http://help.dobt.co',
+          contact: 'mailto:support@dobt.co',
+        }
 
   def content
     footer(class: 'footer') {
@@ -18,14 +24,13 @@ class Dvl::Core::Views::Footer < Dvl::Core::Views.base_view_class.constantize
 
         ul {
           @prepend_links.call if @prepend_links
-          li { a t('dvl_core.footer.status'), href: 'http://status.dobt.co', target: '_blank' }
-          li { a t('dvl_core.footer.legal'), href: 'https://www.dobt.co/terms/', target: '_blank' }
-          li { a t('dvl_core.footer.help'), href: 'http://help.dobt.co', target: '_blank' }
-          li { a t('dvl_core.footer.contact'), href: 'mailto:support@dobt.co' }
+          li { a t('dvl_core.footer.status'),  href: @hrefs[:status] , target: '_blank' }
+          li { a t('dvl_core.footer.legal'),   href: @hrefs[:legal], target: '_blank' }
+          li { a t('dvl_core.footer.help'),    href: @hrefs[:help], target: '_blank' }
+          li { a t('dvl_core.footer.contact'), href: @hrefs[:contact] }
           @append_links.call if @append_links
         }
       }
-
 
       @append.call if @append
     }


### PR DESCRIPTION
I'm keeping the old hardcoded hrefs around as default values because I'm not
sure where else this footer widget is used, and don't want to go around to every
dobt app and update the footers right now.