### PR TITLE
Explicitly set ruby version in Gemfile, for heroku.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,6 @@
 source 'https://rubygems.org'
+ruby '2.3.1'
+
 gemspec
 
 source 'https://rails-assets.org' do


### PR DESCRIPTION
Heroku doesn't respect .ruby-version, it only looks at the ruby
declaration in the Gemfile. dvl-core now requires ruby >= 2.1.0.

https://devcenter.heroku.com/articles/ruby-versions

c.f. https://github.com/dobtco/dvl-core/issues/300