### PR TITLE
Adjust dropdown height and positioning

### DIFF
--- a/vendor/assets/stylesheets/dvl/components/dropdowns.scss
+++ b/vendor/assets/stylesheets/dvl/components/dropdowns.scss
@@ -82,7 +82,7 @@
 }
 
 .dropdown_body {
-  max-height: ($lineHeight * 15) + ($rhythm * 1.5); // Overlap a list item with the bottom edge
+  max-height: ($lineHeight * 15) + ($rhythm * 2.5); // Overlap a list item with the bottom edge
   overflow: auto;
   > li {
 

--- a/vendor/assets/stylesheets/dvl/components/dropdowns.scss
+++ b/vendor/assets/stylesheets/dvl/components/dropdowns.scss
@@ -1,6 +1,10 @@
 .dropdown {
   position: relative;
   display: inline-block;
+
+  .button {
+    display: block;
+  }
 }
 
 // Nav dropdowns

--- a/vendor/assets/stylesheets/dvl/components/dropdowns.scss
+++ b/vendor/assets/stylesheets/dvl/components/dropdowns.scss
@@ -39,6 +39,7 @@
   line-height: $lineHeight;
   position: absolute;
   top: 100%;
+  margin-top: $rhythm / 2;
   left: 0;
   z-index: $z_dropdown;
   background-clip: padding-box;
@@ -77,7 +78,7 @@
 }
 
 .dropdown_body {
-  max-height: ($lineHeight * 15) + $rhythm; // Overlap a list item with the bottom edge
+  max-height: ($lineHeight * 15) + ($rhythm * 1.5); // Overlap a list item with the bottom edge
   overflow: auto;
   > li {
 


### PR DESCRIPTION
From dobtco/tasks-josh#24

Fixes the max dropdown height so that it cuts off in the middle of a list item, indicating that the user can scroll to view more options.

Also adds a bit of spacing between the dropdown click target and menu.

![dropdown_height](https://user-images.githubusercontent.com/1328849/27809393-1b44dc08-6004-11e7-8194-44fc3ac1fdad.png)

I guess I've never bootstrapped `dvl-core` on this computer... I'm running into installation issues with `capybara-webkit`. I'll assign this to @vlymar for review once I straighten that out.
