### PR TITLE
SCREEN 2239 - Make modal more configurable.

### DIFF
--- a/vendor/assets/javascripts/dvl/components/confirmations.coffee
+++ b/vendor/assets/javascripts/dvl/components/confirmations.coffee
@@ -75,6 +75,8 @@ class Dvl.Confirmations.Modal
     'title': 'Are you sure?'
     'cancel-text': 'Cancel'
     'confirm-text': 'Confirm'
+    'confirm-class': 'error'
+    'title-class': 'modal_confirm'
     # cancelCb:
 
   constructor: ($el, message, cb, opts = {}) ->
@@ -91,7 +93,7 @@ class Dvl.Confirmations.Modal
     )
 
     $modal.
-      addClass('modal_confirm').
+      addClass(@options['title-class']).
       find('.modal_content').
       append """
         <div class='modal_body'><p>#{message}</p></div>
@@ -100,7 +102,7 @@ class Dvl.Confirmations.Modal
             <a class='button white' data-dismiss='modal'>
               #{@options['cancel-text']}
             </a>
-            <button class='button error js-popover-confirm'>#{@options['confirm-text']}</button>
+            <button class='button #{@options['confirm-class']} js-popover-confirm'>#{@options['confirm-text']}</button>
           </div>
         </div>
       """


### PR DESCRIPTION
# What

Need to make Modal more configurable.

# Why

To display the modal in the attached image.
![changeprojectowner_confirm](https://user-images.githubusercontent.com/1443346/53108473-b2f03380-34fc-11e9-8873-2d816f66324d.png)
