### PR TITLE
SCREEN 2143 - Support custom confirm modal flows.

### DIFF
--- a/vendor/assets/javascripts/dvl/overrides/rails_allow_action.coffee
+++ b/vendor/assets/javascripts/dvl/overrides/rails_allow_action.coffee
@@ -6,10 +6,23 @@ $.rails.allowAction = ($link) ->
     $link.data('confirmed', true)
     $link.trigger('click.rails')
 
-  new Dvl.Confirmations[if $link.data('confirm-with') == 'popover' then 'Popover' else 'Modal'](
-    $link,
-    $link.attr('data-confirm'),
-    cb
-  )
+  showModal = (options = {}) =>
+    new Dvl.Confirmations[if $link.data('confirm-with') == 'popover' then 'Popover' else 'Modal'](
+      $link,
+      $link.attr('data-confirm'),
+      cb,
+      options
+    )
+    return false
+
+  href = $link.data('confirm-endpoint')
+  callback = $link.data('confirm-call') 
+  if App? && App[callback]?
+    App[callback](showModal, cb, href)
+  else
+    options = {}
+    if title = $link.data('confirm-title')
+      options = $.extend(options, {title: title})
+    showModal(options)
 
   return false


### PR DESCRIPTION
# What

Handle custom confirm modal interactions.

# Why

Screendoor requirement.

# Context

Currently show a modal with some default text + a configurable body. This is not sufficient when we need to interact with a backend to populate the modal with additional information. These changes provide a hook from the application into this modal to allow more application level control over the inputs and handling of the modal.