### PR TITLE
Change Newsletter signup from Campaign Monitor to CityBlog

### DIFF
--- a/vendor/assets/javascripts/dvl/components/newsletter_form.coffee
+++ b/vendor/assets/javascripts/dvl/components/newsletter_form.coffee
@@ -1,14 +1,33 @@
-# Subscribe folks to our "House List" on Campaign Monitor
+# Subscribe to CityBase CityBlog notifications
 $(document).on 'submit', '.newsletter_form', (e) ->
   e.preventDefault()
   $input = $(@).find('input[type=email]')
   return unless $input.val()
 
   $.ajax
-    url: 'https://piper.dobt.co/api/subscribe_to_newsletter'
+    url: 'https://api.hsforms.com/submissions/v3/integration/submit/3064896/168dece9-f564-4e5c-85a0-bf721304d642'
     type: 'post'
+    contentType: 'application/json'
+    datatype: 'json'
     data:
-      email: $input.val()
+      JSON.stringify(
+        {
+          "fields": [
+            {
+              "name": "email",
+              "value": $input.val()
+            },
+            {
+              "name": "subscriptions",
+              "value": "CityBlog"
+            }
+          ],
+          "context": {
+            "pageUri": document.URL,
+            "pageName": document.title
+          }
+        }
+      )
     success: ->
       $input.flashPlaceholder('Thanks!', 2000)
     error: ->


### PR DESCRIPTION
# What
Change the newsletter signup from Campaign Monitor via Piper to CityBlog.

# Why
New blog.